### PR TITLE
Replace deprecated Image layout prop with fill

### DIFF
--- a/src/app/works/page.tsx
+++ b/src/app/works/page.tsx
@@ -52,7 +52,7 @@ export default function WorksPage() {
             <Link key={index} href={work.href}>
               <div className="border border-gray-200/80 rounded-sm overflow-hidden shadow-sm hover:shadow-md transition-shadow duration-300 bg-white/50">
                 <div className="relative w-full h-60">
-                  <Image src={work.image} alt={work.title} layout="fill" objectFit="cover" />
+                  <Image src={work.image} alt={work.title} fill className="object-cover" />
         </div>
                 <div className="p-6">
                   <h2 className="text-xl font-bold mb-2" style={{ fontFamily: '"Shippori Mincho", serif' }}>{work.title}</h2>


### PR DESCRIPTION
## Summary
- use `fill` boolean prop instead of deprecated `layout="fill"`
- apply Tailwind `object-cover` class instead of `objectFit="cover"`

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Shippori Mincho` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_689e1e0c3668832893000fb6852fe247