### PR TITLE
chore: remove unused react imports from client layout

### DIFF
--- a/src/components/ClientLayout.tsx
+++ b/src/components/ClientLayout.tsx
@@ -2,7 +2,7 @@
 
 import { AnimatePresence, motion } from 'framer-motion';
 import { usePathname } from 'next/navigation';
-import { useState, useEffect, cloneElement, isValidElement } from 'react'; // cloneElement, isValidElement をインポート
+import { useState, useEffect } from 'react';
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
 import CustomCursor from "@/components/CustomCursor";


### PR DESCRIPTION
## Summary
- drop unused `cloneElement` and `isValidElement` from `ClientLayout`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e1e0a3d60832891ccbaea62666d7b