### PR TITLE
Remove external Google font to avoid fetch error

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,15 +1,7 @@
 import React from "react";
 import type { Metadata } from "next";
-import { Shippori_Mincho } from "next/font/google";
 import "../globals.css";
 import ClientLayout from "@/components/ClientLayout";
-
-const shipporiMincho = Shippori_Mincho({
-  subsets: ["latin"],
-  weight: ["400", "500", "600", "700", "800"],
-  variable: "--font-shippori-mincho",
-  display: "swap",
-});
 
 export const metadata: Metadata = {
   title: "YUDAI | Architectural Designer & Software Engineer",
@@ -23,10 +15,7 @@ export default function RootLayout({
 }): React.JSX.Element {
   return (
     <html lang="ja">
-      <body 
-        className={`${shipporiMincho.variable} font-sans`}
-        style={{ fontFamily: "var(--font-shippori-mincho)" }}
-      >
+      <body className="font-serif">
         <ClientLayout>
           {children}
         </ClientLayout>

--- a/src/globals.css
+++ b/src/globals.css
@@ -128,7 +128,7 @@ body {
     linear-gradient(0deg, transparent 24%, rgba(0,0,0,.1) 25%, rgba(0,0,0,.1) 26%, transparent 27%, transparent 74%, rgba(0,0,0,.1) 75%, rgba(0,0,0,.1) 76%, transparent 77%, transparent),
     linear-gradient(90deg, transparent 24%, rgba(0,0,0,.1) 25%, rgba(0,0,0,.1) 26%, transparent 27%, transparent 74%, rgba(0,0,0,.1) 75%, rgba(0,0,0,.1) 76%, transparent 77%, transparent);
   background-size: 50px 50px; /* Adjust grid size as needed */
-  font-family: var(--font-shippori-mincho), serif;
+  font-family: serif;
   font-size: 0.95rem; /* 基本の文字サイズを少し小さくする */
   line-height: 1.8; /* 行間を広げる */
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -41,8 +41,8 @@ const config: Config = {
         border: "var(--border)",
       },
       fontFamily: {
-        sans: ["var(--font-noto-sans-jp)"],
-        serif: ["var(--font-shippori-mincho)"],
+        sans: ["ui-sans-serif", "system-ui", "sans-serif"],
+        serif: ["serif"],
       },
     },
   },


### PR DESCRIPTION
## Summary
- use system serif font instead of Google `Shippori Mincho`
- update Tailwind config to rely on generic fonts
- drop font variable from global styles

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e75d4c8648328804c92eadb3aa619