### PR TITLE
Add fade-in and tag filtered works links for Space & Creation

### DIFF
--- a/materials/works.json
+++ b/materials/works.json
@@ -4,41 +4,47 @@
     "title": "Project Alpha",
     "description": "This is a description for Project Alpha. It showcases innovative design and engineering principles.",
     "monochromeImage": "/images/film_bw_1.jpg",
-    "colorImage": "/images/film_color_1.jpg"
+    "colorImage": "/images/film_color_1.jpg",
+    "tags": ["realestate", "architecture"]
   },
   {
     "id": "project-beta",
     "title": "Project Beta",
     "description": "A deep dive into sustainable architecture and urban planning.",
     "monochromeImage": "/images/film_bw_1.jpg",
-    "colorImage": "/images/film_color_1.jpg"
+    "colorImage": "/images/film_color_1.jpg",
+    "tags": ["architecture"]
   },
   {
     "id": "project-gamma",
     "title": "Project Gamma",
     "description": "Exploring the intersection of traditional craftsmanship and modern technology.",
     "monochromeImage": "/images/film_bw_1.jpg",
-    "colorImage": "/images/film_color_1.jpg"
+    "colorImage": "/images/film_color_1.jpg",
+    "tags": ["crafting"]
   },
   {
     "id": "project-delta",
     "title": "Project Delta",
     "description": "A study on material science and its application in structural design.",
     "monochromeImage": "/images/film_bw_1.jpg",
-    "colorImage": "/images/film_color_1.jpg"
+    "colorImage": "/images/film_color_1.jpg",
+    "tags": ["living"]
   },
   {
     "id": "project-epsilon",
     "title": "Project Epsilon",
     "description": "Innovative solutions for compact living spaces in urban environments.",
     "monochromeImage": "/images/film_bw_1.jpg",
-    "colorImage": "/images/film_color_1.jpg"
+    "colorImage": "/images/film_color_1.jpg",
+    "tags": ["living", "realestate"]
   },
   {
     "id": "project-zeta",
     "title": "Project Zeta",
     "description": "A conceptual project focusing on future city infrastructure.",
     "monochromeImage": "/images/film_bw_1.jpg",
-    "colorImage": "/images/film_color_1.jpg"
+    "colorImage": "/images/film_color_1.jpg",
+    "tags": ["architecture"]
   }
 ]

--- a/src/app/works/page.tsx
+++ b/src/app/works/page.tsx
@@ -1,14 +1,14 @@
 
-"use client";
-
 import React from 'react';
-import { useSearchParams } from 'next/navigation';
 import WorkCard from '@/components/WorkCard';
 import worksData from '../../../materials/works.json';
 
-const WorksPage: React.FC = () => {
-  const searchParams = useSearchParams();
-  const tag = searchParams.get('tag');
+interface WorksPageProps {
+  searchParams?: { tag?: string };
+}
+
+const WorksPage: React.FC<WorksPageProps> = ({ searchParams }) => {
+  const tag = searchParams?.tag;
 
   const filteredWorks = tag
     ? worksData.filter((work) => work.tags && work.tags.includes(tag))

--- a/src/app/works/page.tsx
+++ b/src/app/works/page.tsx
@@ -1,14 +1,24 @@
 
+"use client";
+
 import React from 'react';
+import { useSearchParams } from 'next/navigation';
 import WorkCard from '@/components/WorkCard';
 import worksData from '../../../materials/works.json';
 
 const WorksPage: React.FC = () => {
+  const searchParams = useSearchParams();
+  const tag = searchParams.get('tag');
+
+  const filteredWorks = tag
+    ? worksData.filter((work) => work.tags && work.tags.includes(tag))
+    : worksData;
+
   return (
     <div className="min-h-screen bg-white text-gray-900 p-8">
       <h1 className="text-5xl font-extrabold mb-12 mt-24 text-center">Works</h1>
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-2 gap-8">
-        {worksData.map((work) => (
+        {filteredWorks.map((work) => (
           <WorkCard
             key={work.id}
             id={work.id}

--- a/src/components/InterestsSection.tsx
+++ b/src/components/InterestsSection.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Image from 'next/image';
+import Link from 'next/link';
 import { motion, useInView, useScroll, useTransform } from 'framer-motion';
 import { useEffect, useRef, useState } from 'react';
 
@@ -10,21 +11,25 @@ const interests = {
       title: 'Real Estate',
       description: '空間の価値を捉え、未来の可能性を創造する。',
       imageUrl: '/images/building_osaka.jpg',
+      tag: 'realestate',
     },
     {
       title: 'Architecture',
       description: '機能と美が融合した、心地よい空間を追求する。',
       imageUrl: '/images/drawing_aris.jpg',
+      tag: 'architecture',
     },
     {
       title: 'Living',
       description: '日々の営みを豊かにする、ささやかな工夫と発見。',
       imageUrl: '/images/kurashi.jpg',
+      tag: 'living',
     },
     {
       title: 'Crafting',
       description: '手を動かし、思考を形にする創造の喜び。',
       imageUrl: '/images/me_mad.jpg',
+      tag: 'crafting',
     },
   ],
   cultureAndExploration: [
@@ -270,7 +275,13 @@ export default function InterestsSection() {
           viewport={{ once: true }}
           transition={{ duration: 0.6 }}
         >
-          <div className="relative w-full md:w-1/2 h-64 overflow-hidden">
+          <motion.div
+            className="relative w-full md:w-1/2 h-64 overflow-hidden"
+            initial={{ opacity: 0, x: index % 2 === 0 ? -50 : 50 }}
+            whileInView={{ opacity: 1, x: 0 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.8 }}
+          >
             <Image
               src={interest.imageUrl}
               alt={interest.title}
@@ -278,7 +289,7 @@ export default function InterestsSection() {
               className="object-cover"
               sizes="(max-width:768px)100vw,(max-width:1024px)50vw,50vw"
             />
-          </div>
+          </motion.div>
           <div className="md:w-1/2">
             <h4 className="text-2xl font-semibold mb-4">
               {interest.title}
@@ -286,6 +297,14 @@ export default function InterestsSection() {
             <p className="opacity-80 leading-relaxed">
               {interest.description}
             </p>
+            {interest.tag && (
+              <Link
+                href={`/works?tag=${interest.tag}`}
+                className="mt-4 inline-block text-sm font-medium underline"
+              >
+                works →
+              </Link>
+            )}
           </div>
         </motion.div>
       ))}


### PR DESCRIPTION
## Summary
- Fade and slide in the first image for each "Space & Creation" interest card
- Add `works →` tag links on interest cards to open the Works page filtered by that tag
- Support tag-based filtering on the Works page and add tags to works data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689fee6364e88328a1e06f3f8e8505dd