### PR TITLE
Link interest cards to gallery, special pages and filtered works

### DIFF
--- a/materials/works.json
+++ b/materials/works.json
@@ -4,41 +4,47 @@
     "title": "Project Alpha",
     "description": "This is a description for Project Alpha. It showcases innovative design and engineering principles.",
     "monochromeImage": "/images/film_bw_1.jpg",
-    "colorImage": "/images/film_color_1.jpg"
+    "colorImage": "/images/film_color_1.jpg",
+    "tags": ["data-analysis"]
   },
   {
     "id": "project-beta",
     "title": "Project Beta",
     "description": "A deep dive into sustainable architecture and urban planning.",
     "monochromeImage": "/images/film_bw_1.jpg",
-    "colorImage": "/images/film_color_1.jpg"
+    "colorImage": "/images/film_color_1.jpg",
+    "tags": ["design-programming"]
   },
   {
     "id": "project-gamma",
     "title": "Project Gamma",
     "description": "Exploring the intersection of traditional craftsmanship and modern technology.",
     "monochromeImage": "/images/film_bw_1.jpg",
-    "colorImage": "/images/film_color_1.jpg"
+    "colorImage": "/images/film_color_1.jpg",
+    "tags": ["artificial-intelligence"]
   },
   {
     "id": "project-delta",
     "title": "Project Delta",
     "description": "A study on material science and its application in structural design.",
     "monochromeImage": "/images/film_bw_1.jpg",
-    "colorImage": "/images/film_color_1.jpg"
+    "colorImage": "/images/film_color_1.jpg",
+    "tags": ["data-analysis"]
   },
   {
     "id": "project-epsilon",
     "title": "Project Epsilon",
     "description": "Innovative solutions for compact living spaces in urban environments.",
     "monochromeImage": "/images/film_bw_1.jpg",
-    "colorImage": "/images/film_color_1.jpg"
+    "colorImage": "/images/film_color_1.jpg",
+    "tags": ["design-programming"]
   },
   {
     "id": "project-zeta",
     "title": "Project Zeta",
     "description": "A conceptual project focusing on future city infrastructure.",
     "monochromeImage": "/images/film_bw_1.jpg",
-    "colorImage": "/images/film_color_1.jpg"
+    "colorImage": "/images/film_color_1.jpg",
+    "tags": ["artificial-intelligence"]
   }
 ]

--- a/src/app/special/[slug]/page.tsx
+++ b/src/app/special/[slug]/page.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from 'next';
+
+type PageProps = { params: { slug: string } };
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const title = decodeURIComponent(params.slug);
+  return { title: `Special | ${title}`, description: `Special page for "${title}"` };
+}
+
+export default function SpecialPage({ params }: PageProps) {
+  const title = decodeURIComponent(params.slug);
+  return (
+    <main className="max-w-4xl mx-auto px-4 py-10">
+      <h1 className="text-3xl font-bold mb-4">Special: {title}</h1>
+      <p className="text-gray-600">このページは「{title}」の特設ページです。</p>
+    </main>
+  );
+}

--- a/src/app/works/page.tsx
+++ b/src/app/works/page.tsx
@@ -3,12 +3,22 @@ import React from 'react';
 import WorkCard from '@/components/WorkCard';
 import worksData from '../../../materials/works.json';
 
-const WorksPage: React.FC = () => {
+interface WorksPageProps {
+  searchParams: { tag?: string };
+}
+
+const WorksPage: React.FC<WorksPageProps> = ({ searchParams }) => {
+  const tag = searchParams?.tag;
+  const filteredWorks = tag
+    ? worksData.filter((work) => work.tags?.includes(tag))
+    : worksData;
   return (
     <div className="min-h-screen bg-white text-gray-900 p-8">
-      <h1 className="text-5xl font-extrabold mb-12 mt-24 text-center">Works</h1>
+      <h1 className="text-5xl font-extrabold mb-12 mt-24 text-center">
+        Works{tag ? `: ${tag}` : ''}
+      </h1>
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-2 gap-8">
-        {worksData.map((work) => (
+        {filteredWorks.map((work) => (
           <WorkCard
             key={work.id}
             id={work.id}

--- a/src/components/InterestsSection.tsx
+++ b/src/components/InterestsSection.tsx
@@ -1,8 +1,19 @@
 'use client';
 
 import Image from 'next/image';
+import Link from 'next/link';
 import { motion, useInView, useScroll, useTransform } from 'framer-motion';
 import { useEffect, useRef, useState } from 'react';
+
+const slugify = (text: string) =>
+  text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-');
+
+const getCultureLink = (title: string) =>
+  title === 'Photography' ? '/photos' : `/special/${slugify(title)}`;
+
+const getDigitalLink = (title: string) => `/works?tag=${slugify(title)}`;
 
 const interests = {
   spaceAndCreation: [
@@ -406,38 +417,43 @@ export default function InterestsSection() {
         <div className="relative z-10 grid grid-cols-[repeat(12,1fr)] grid-rows-[repeat(15,1fr)] w-full max-w-6xl mx-auto h-[80vh] md:h-[90vh] gap-4">
           {layout.map((block) =>
             block.interest ? (
-              <motion.div
+              <Link
+                href={getDigitalLink(block.interest.title)}
                 key={block.key}
                 className={`group cursor-pointer ${block.className}`}
-                initial={{ opacity: 0, y: 40 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                viewport={{ once: true }}
-                transition={{ duration: 0.6 }}
                 onMouseEnter={() => setHoveredImage(block.interest!.imageUrl)}
                 onMouseLeave={() => setHoveredImage(null)}
               >
-                <div className="relative w-full h-full min-h-0 overflow-hidden rounded-lg shadow-lg bg-gray-800/20">
-                  <Image
-                    src={block.interest.imageUrl}
-                    alt={block.interest.title}
-                    fill
-                    className="object-cover transition-transform duration-500 group-hover:scale-110"
-                    sizes="(max-width:768px)100vw,(max-width:1024px)50vw,33vw"
-                  />
-                </div>
-                <h4
-                  className="text-xl font-semibold mt-4 mb-2 text-white"
-                  style={{}}
+                <motion.div
+                  className="w-full h-full"
+                  initial={{ opacity: 0, y: 40 }}
+                  whileInView={{ opacity: 1, y: 0 }}
+                  viewport={{ once: true }}
+                  transition={{ duration: 0.6 }}
                 >
-                  {block.interest.title}
-                </h4>
-                <p
-                  className="text-base opacity-80 leading-relaxed"
-                  style={{}}
-                >
-                  {block.interest.description}
-                </p>
-              </motion.div>
+                  <div className="relative w-full h-full min-h-0 overflow-hidden rounded-lg shadow-lg bg-gray-800/20">
+                    <Image
+                      src={block.interest.imageUrl}
+                      alt={block.interest.title}
+                      fill
+                      className="object-cover transition-transform duration-500 group-hover:scale-110"
+                      sizes="(max-width:768px)100vw,(max-width:1024px)50vw,33vw"
+                    />
+                  </div>
+                  <h4
+                    className="text-xl font-semibold mt-4 mb-2 text-white"
+                    style={{}}
+                  >
+                    {block.interest.title}
+                  </h4>
+                  <p
+                    className="text-base opacity-80 leading-relaxed"
+                    style={{}}
+                  >
+                    {block.interest.description}
+                  </p>
+                </motion.div>
+              </Link>
             ) : (
               <div key={block.key} className={`${block.className} bg-white/5 rounded-md`}>
                 {hoveredImage && (
@@ -554,30 +570,34 @@ return (
         </div>
         <div className="grid grid-cols-1 md:grid-cols-3 gap-x-16 gap-y-32 max-w-6xl mx-auto">
           {interests.cultureAndExploration.map((interest, index) => (
-            <motion.div
+            <Link
+              href={getCultureLink(interest.title)}
               key={interest.title}
               className="group cursor-pointer"
-              initial={{ opacity: 0, y: 20 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              viewport={{ once: true }}
-              transition={{ duration: 0.5, delay: index * 0.1 }}
             >
-              <div className="relative h-80 mb-6 overflow-hidden rounded-lg shadow-lg">
-                <Image
-                  src={interest.imageUrl}
-                  alt={interest.title}
-                  fill
-                  className="object-cover transition-transform duration-500 group-hover:scale-110"
-                  sizes="(max-width:768px)100vw,(max-width:1024px)50vw,33vw"
-                />
-              </div>
-              <h4 className="text-xl font-semibold mb-2">
-                {interest.title}
-              </h4>
-              <p className="text-base opacity-80 leading-relaxed">
-                {interest.description}
-              </p>
-            </motion.div>
+              <motion.div
+                initial={{ opacity: 0, y: 20 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true }}
+                transition={{ duration: 0.5, delay: index * 0.1 }}
+              >
+                <div className="relative h-80 mb-6 overflow-hidden rounded-lg shadow-lg">
+                  <Image
+                    src={interest.imageUrl}
+                    alt={interest.title}
+                    fill
+                    className="object-cover transition-transform duration-500 group-hover:scale-110"
+                    sizes="(max-width:768px)100vw,(max-width:1024px)50vw,33vw"
+                  />
+                </div>
+                <h4 className="text-xl font-semibold mb-2">
+                  {interest.title}
+                </h4>
+                <p className="text-base opacity-80 leading-relaxed">
+                  {interest.description}
+                </p>
+              </motion.div>
+            </Link>
           ))}
         </div>
       </motion.section>


### PR DESCRIPTION
## Summary
- Add slug helpers and link interest cards: photography to gallery, others to special pages, digital items to works with tag filtering
- Filter Works page by optional tag query
- Annotate works data with tags and scaffold special page route

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689fefd81b048328ac5412bf7259e7c8