### PR TITLE
Add social media links to contact page and footer

### DIFF
--- a/materials/text.md
+++ b/materials/text.md
@@ -47,9 +47,10 @@
 
 ## ソーシャルメディアリンク
 
-- Twitter: 
-- LinkedIn: 
-- GitHub: 
+- Instagram: https://www.instagram.com/babachan_1222/
+- GitHub: https://github.com/vzwtim
+- X: https://x.com/yudaizit
+- note: https://note.com/yubayuba
 
 ## 連絡先情報
 

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -47,9 +47,42 @@ export default function Contact() {
             ソーシャルメディア
           </h2>
           <div className="flex justify-center space-x-8 text-xl">
-            <a href="#" className="hover:text-[#b33953] transition-colors" style={{ fontFamily: '"Shippori Mincho", serif' }}>Twitter</a>
-            <a href="#" className="hover:text-[#b33953] transition-colors" style={{ fontFamily: '"Shippori Mincho", serif' }}>LinkedIn</a>
-            <a href="#" className="hover:text-[#b33953] transition-colors" style={{ fontFamily: '"Shippori Mincho", serif' }}>GitHub</a>
+            <a
+              href="https://www.instagram.com/babachan_1222/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-[#b33953] transition-colors"
+              style={{ fontFamily: '"Shippori Mincho", serif' }}
+            >
+              Instagram
+            </a>
+            <a
+              href="https://github.com/vzwtim"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-[#b33953] transition-colors"
+              style={{ fontFamily: '"Shippori Mincho", serif' }}
+            >
+              GitHub
+            </a>
+            <a
+              href="https://x.com/yudaizit"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-[#b33953] transition-colors"
+              style={{ fontFamily: '"Shippori Mincho", serif' }}
+            >
+              X (Twitter)
+            </a>
+            <a
+              href="https://note.com/yubayuba"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-[#b33953] transition-colors"
+              style={{ fontFamily: '"Shippori Mincho", serif' }}
+            >
+              note
+            </a>
           </div>
         </section>
       </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,6 +1,7 @@
 
 import Link from 'next/link';
-import { FaInstagram, FaTwitter, FaGithub, FaPencilAlt } from 'react-icons/fa';
+import { FaInstagram, FaGithub, FaPencilAlt } from 'react-icons/fa';
+import { FaXTwitter } from 'react-icons/fa6';
 
 const Footer = () => {
   return (
@@ -11,22 +12,42 @@ const Footer = () => {
             <p className="text-sm">&copy; {new Date().getFullYear()} YUDAI. All Rights Reserved.</p>
           </div>
           <div className="flex space-x-4">
-            <Link href="https://instagram.com" passHref>
+            <Link
+              href="https://www.instagram.com/babachan_1222/"
+              target="_blank"
+              rel="noopener noreferrer"
+              passHref
+            >
               <span className="text-xl hover:text-[#bb5555] transition-colors duration-300 cursor-pointer">
                 <FaInstagram />
               </span>
             </Link>
-            <Link href="https://twitter.com" passHref>
+            <Link
+              href="https://x.com/yudaizit"
+              target="_blank"
+              rel="noopener noreferrer"
+              passHref
+            >
               <span className="text-xl hover:text-[#bb5555] transition-colors duration-300 cursor-pointer">
-                <FaTwitter />
+                <FaXTwitter />
               </span>
             </Link>
-            <Link href="https://note.com" passHref>
+            <Link
+              href="https://note.com/yubayuba"
+              target="_blank"
+              rel="noopener noreferrer"
+              passHref
+            >
               <span className="text-xl hover:text-[#bb5555] transition-colors duration-300 cursor-pointer">
                 <FaPencilAlt />
               </span>
             </Link>
-            <Link href="https://github.com" passHref>
+            <Link
+              href="https://github.com/vzwtim"
+              target="_blank"
+              rel="noopener noreferrer"
+              passHref
+            >
               <span className="text-xl hover:text-[#bb5555] transition-colors duration-300 cursor-pointer">
                 <FaGithub />
               </span>


### PR DESCRIPTION
## Summary
- add Instagram, GitHub, X, and note links to contact page
- update footer icons and targets with personal social media URLs
- document social media URLs in materials

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ff11472048328955e893d7129b389