### PR TITLE
feat: support stage-based skills data

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,13 +1,16 @@
 "use client";
 
 import Image from 'next/image';
+import { useState } from 'react';
 import SkillsChart from '@/components/SkillSet';
+import { careerStages, skillsByStage, CareerStageKey } from '@/data/skills';
 
 export default function About() {
+  const [stage, setStage] = useState<CareerStageKey>(careerStages[0].key);
+
   return (
     <main className="bg-[#ffffff] text-[#232024] pt-24 md:pt-28 px-8 md:px-16 lg:px-32 min-h-screen">
       <div className="max-w-6xl mx-auto">
-        
 
         {/* Profile Section */}
         <section className="flex flex-col items-center mb-24">
@@ -21,13 +24,11 @@ export default function About() {
             />
           </div>
           <div className="text-center">
-            
             <p className="text-lg leading-relaxed mb-4">
               大学で建築・都市・社会・環境を学び、現在は不動産デベロッパーとして、用地取得・開発・アセットマネジメント業務に従事。経営企画・DXプロジェクトにも参画し、ビルやマンション単位の取得開発に携わっています。
-        </p>
+            </p>
             <p className="text-lg leading-relaxed">
-              都市のダイナミクスを見つめながら、和室・ちゃぶ台・ミニマルな暮らしを軸に、日々の発見や街歩きの記録を積み重ねています。一級建築士の取得を目指しつつ、将来的には街と暮らしをつなぐ事業に挑戦予定です。
-              趣味は、盆栽や書道などの日本文化、写真撮影、そして旅行。特に、自然や歴史的な場所を訪れることが好きです。
+              都市のダイナミクスを見つめながら、和室・ちゃぶ台・ミニマルな暮らしを軸に、日々の発見や街歩きの記録を積み重ねています。一級建築士の取得を目指しつつ、将来的には街と暮らしをつなぐ事業に挑戦予定です。趣味は、盆栽や書道などの日本文化、写真撮影、そして旅行。特に、自然や歴史的な場所を訪れることが好きです。
             </p>
           </div>
         </section>
@@ -55,11 +56,29 @@ export default function About() {
               </ul>
             </div>
           </div>
-      </section>
+        </section>
 
         {/* Skills Section */}
-        <SkillsChart />
-    </div>
+        <section className="mb-24">
+          <div className="flex justify-center gap-2 mb-6">
+            {careerStages.map(({ key, label }) => (
+              <button
+                key={key}
+                onClick={() => setStage(key)}
+                className={`px-3 py-1 rounded-md text-sm border transition ${
+                  stage === key
+                    ? 'bg-[#bb5555] text-white border-[#bb5555]'
+                    : 'bg-white text-neutral-700 border-neutral-200 hover:bg-neutral-50'
+                }`}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+          <SkillsChart stageData={skillsByStage[stage]} />
+        </section>
+      </div>
     </main>
   );
 }
+

--- a/src/components/SkillSet.tsx
+++ b/src/components/SkillSet.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useMemo, useState } from "react";
+import React, { useMemo, useState, useEffect } from "react";
 import {
   RadarChart,
   PolarGrid,
@@ -16,128 +16,8 @@ import {
   Bar,
   Cell,
 } from "recharts";
+import { SCORE, StageSkillData } from "@/data/skills";
 
-// =====================================
-// 五目飯スキルチャート（Radar + Bar） - 拡張版
-// ・カテゴリとツールを大幅拡張
-// ・プリセット切替 / カテゴリチップON-OFF / 検索フィルタ
-// =====================================
-
-// === スコア定義 ===
-// 5 = 使える（即戦力） / 2 = AIと一緒ならできる・学習中 / 1 = これから
-const SCORE = { STRONG: 5, ASSISTED: 2, FUTURE: 1 } as const;
-
-// === 基本カテゴリ ===
-const baseCategories = [
-  { key: "programming", label: "プログラミング", current: 4, growth: 5 },
-  { key: "architecture", label: "建築・設計", current: 5, growth: 4 },
-  { key: "design", label: "デザイン", current: 4, growth: 5 },
-  { key: "gis", label: "GIS・可視化", current: 5, growth: 4 },
-  { key: "office", label: "office365", current: 5, growth: 3 },
-  { key: "data", label: "データ分析", current: 2, growth: 5 },
-  { key: "realestate", label: "不動産", current: 5, growth: 4 },
-  { key: "finance", label: "金融", current: 4, growth: 5 },
-  { key: "dx", label: "DX/自動化", current: 3, growth: 5 },
-];
-
-// === 追加カテゴリ（網羅） ===
-const extraCategories = [
-  { key: "marketing", label: "マーケティング", current: 3, growth: 5 },
-  { key: "pm", label: "プロジェクトマネジメント", current: 4, growth: 5 },
-  { key: "legal", label: "法務・コンプライアンス", current: 2, growth: 4 },
-  { key: "language", label: "語学", current: 3, growth: 4 },
-  { key: "communication", label: "コミュニケーション・プレゼン", current: 4, growth: 5 },
-  { key: "education", label: "教育・研修", current: 3, growth: 4 },
-  { key: "research", label: "リサーチ・分析", current: 4, growth: 5 },
-  { key: "innovation", label: "イノベーション/新規事業", current: 3, growth: 5 },
-  { key: "sustainability", label: "サステナビリティ/ESG", current: 2, growth: 5 },
-  { key: "customer", label: "顧客対応・CX", current: 1, growth: 1 },
-  { key: "training", label: "トレーニング・コーチング", current: 3, growth: 4 },
-];
-
-const allCategories = [...baseCategories, ...extraCategories];
-
-// === ツール（スキル要素） ===
-const baseTools = [
-  // プログラミング
-  { label: "Python", cat: "プログラミング", level: SCORE.STRONG },
-  { label: "JavaScript / TypeScript", cat: "プログラミング", level: SCORE.ASSISTED },
-  { label: "Node.js", cat: "プログラミング", level: SCORE.ASSISTED },
-  // 建築・設計
-  { label: "AutoCAD", cat: "建築・設計", level: SCORE.STRONG },
-  { label: "SketchUp", cat: "建築・設計", level: SCORE.STRONG },
-  { label: "Rhino + Grasshopper", cat: "建築・設計", level: SCORE.STRONG },
-  { label: "Twinmotion", cat: "建築・設計", level: SCORE.STRONG },
-  { label: "Lumion", cat: "建築・設計", level: SCORE.ASSISTED },
-  // デザイン
-  { label: "Adobe Illustrator", cat: "デザイン", level: SCORE.STRONG },
-  { label: "Adobe Photoshop", cat: "デザイン", level: SCORE.STRONG },
-  { label: "Blender", cat: "デザイン", level: SCORE.ASSISTED },
-  { label: "Inkscape", cat: "デザイン", level: SCORE.ASSISTED },
-  { label: "DaVinci Resolve", cat: "デザイン", level: SCORE.ASSISTED },
-  // GIS
-  { label: "ArcGIS", cat: "GIS・可視化", level: SCORE.STRONG },
-  { label: "QGIS", cat: "GIS・可視化", level: SCORE.STRONG },
-  { label: "Kepler.gl", cat: "GIS・可視化", level: SCORE.STRONG },
-  // office365
-  { label: "Excel", cat: "office365", level: SCORE.STRONG },
-  { label: "PowerPoint", cat: "office365", level: SCORE.STRONG },
-  // データ
-  { label: "Pandas", cat: "データ分析", level: SCORE.ASSISTED },
-  { label: "NumPy", cat: "データ分析", level: SCORE.ASSISTED },
-  // 不動産
-  { label: "土地仕入・ボリューム検討", cat: "不動産", level: SCORE.STRONG },
-  { label: "事業収支/DCF（Excel）", cat: "不動産", level: SCORE.STRONG },
-  { label: "不動産証券化の基礎", cat: "不動産", level: SCORE.ASSISTED },
-  // 金融
-  { label: "DCF/NPV・IRR", cat: "金融", level: SCORE.STRONG },
-  { label: "LTV/DSCR", cat: "金融", level: SCORE.ASSISTED },
-  // DX
-  { label: "業務自動化（Python+Excel）", cat: "DX/自動化", level: SCORE.ASSISTED },
-  { label: "ダッシュボード試作（Kepler/BI）", cat: "DX/自動化", level: SCORE.ASSISTED },
-];
-
-const extraTools = [
-  // マーケティング
-  { label: "Webマーケティング", cat: "マーケティング", level: SCORE.ASSISTED },
-  { label: "SEO・SNS運用", cat: "マーケティング", level: SCORE.ASSISTED },
-  { label: "広告運用(Google/Facebook)", cat: "マーケティング", level: SCORE.ASSISTED },
-  // PM
-  { label: "進行管理", cat: "プロジェクトマネジメント", level: SCORE.STRONG },
-  { label: "チームマネジメント", cat: "プロジェクトマネジメント", level: SCORE.STRONG },
-  { label: "アジャイル開発管理", cat: "プロジェクトマネジメント", level: 3 },
-  // 法務
-  { label: "契約・建築法務", cat: "法務・コンプライアンス", level: SCORE.ASSISTED },
-  { label: "都市計画法/建築基準法", cat: "法務・コンプライアンス", level: SCORE.ASSISTED },
-  // 語学
-  { label: "英語業務対応", cat: "語学", level: 3 },
-  { label: "ビジネス英語メール", cat: "語学", level: 3 },
-  // コミュニケーション
-  { label: "プレゼンテーション", cat: "コミュニケーション・プレゼン", level: SCORE.STRONG },
-  { label: "ファシリテーション", cat: "コミュニケーション・プレゼン", level: SCORE.STRONG },
-  // 教育
-  { label: "社内研修講師", cat: "教育・研修", level: 3 },
-  { label: "外部セミナー登壇", cat: "教育・研修", level: SCORE.ASSISTED },
-  // リサーチ
-  { label: "市場調査・競合分析", cat: "リサーチ・分析", level: SCORE.STRONG },
-  { label: "ユーザーインタビュー", cat: "リサーチ・分析", level: 3 },
-  // 新規事業
-  { label: "事業アイデア創出", cat: "イノベーション/新規事業", level: 3 },
-  { label: "PoC企画・実施", cat: "イノベーション/新規事業", level: 3 },
-  // ESG
-  { label: "ESGレポート作成", cat: "サステナビリティ/ESG", level: SCORE.ASSISTED },
-  { label: "環境配慮設計", cat: "サステナビリティ/ESG", level: SCORE.ASSISTED },
-  // CX
-  { label: "顧客満足度分析", cat: "顧客対応・CX", level: 1 },
-  { label: "カスタマーサクセス運用", cat: "顧客対応・CX", level: 3 },
-  // トレーニング
-  { label: "1on1コーチング", cat: "トレーニング・コーチング", level: 3 },
-  { label: "キャリア面談", cat: "トレーニング・コーチング", level: 3 },
-];
-
-const allToolsRaw = [...baseTools, ...extraTools];
-
-// === 表示順 ===
 const CAT_ORDER = [
   "プログラミング",
   "データ分析",
@@ -160,32 +40,27 @@ const CAT_ORDER = [
 ];
 
 const COLORS = {
-  strong: "#bb5555", // くすんだ赤
-  assisted: "#008877", // 深みのあるティールグリーン
+  strong: "#bb5555",
+  assisted: "#008877",
   radarCurrent: "#bb5555",
   radarGrowth: "#008877",
 };
 
-export default function SkillsChart() {
-  const [selectedCats, setSelectedCats] = useState<string[]>([
-    "建築・設計",
-    "デザイン",
-    "GIS・可視化",
-    "不動産",
-    "金融",
-    "プログラミング",
-    "データ分析",
-    "DX/自動化",
-  ]);
+export default function SkillsChart({ stageData }: { stageData: StageSkillData }) {
+  const [selectedCats, setSelectedCats] = useState<string[]>(stageData.categories.map((c) => c.label));
   const [search, setSearch] = useState("");
 
+  useEffect(() => {
+    setSelectedCats(stageData.categories.map((c) => c.label));
+  }, [stageData]);
+
   const radarData = useMemo(
-    () => allCategories.filter((c) => selectedCats.includes(c.label)),
-    [selectedCats]
+    () => stageData.categories.filter((c) => selectedCats.includes(c.label)),
+    [stageData, selectedCats]
   );
 
   const tools = useMemo(() => {
-    return allToolsRaw
+    return stageData.tools
       .filter((t) => selectedCats.includes(t.cat))
       .filter((t) => (search ? t.label.toLowerCase().includes(search.toLowerCase()) : true))
       .slice()
@@ -196,13 +71,12 @@ export default function SkillsChart() {
         return a.label.localeCompare(b.label, "ja");
       })
       .map((d, i) => ({ ...d, idx: i }));
-  }, [selectedCats, search]);
+  }, [stageData, selectedCats, search]);
 
   return (
     <div className="min-h-screen w-full bg-white py-10 px-4">
-      <div className="max-w-7xl mx-auto mb-8"> {/* mb-8で下に余白 */}
+      <div className="max-w-7xl mx-auto mb-8">
         <div className="flex flex-wrap gap-2">
-          {/* カテゴリチップのボタンたち */}
           {CAT_ORDER.map((label) => (
             <button
               key={label}
@@ -224,21 +98,28 @@ export default function SkillsChart() {
       </div>
 
       <div className="max-w-7xl mx-auto flex flex-col lg:flex-row gap-8">
-        
-
-        
-
         {/* レーダーチャート */}
         <section className="bg-white rounded-2xl shadow p-6 w-full lg:w-1/2">
-          
           <div className="w-full h-[360px]">
             <ResponsiveContainer width="100%" height="100%">
               <RadarChart data={radarData} outerRadius={120}>
                 <PolarGrid />
                 <PolarAngleAxis dataKey="label" />
                 <PolarRadiusAxis domain={[0, 10]} tickCount={6} />
-                <Radar name="現在" dataKey="current" stroke={COLORS.radarCurrent} fill={COLORS.radarCurrent} fillOpacity={0.35} />
-                <Radar name="伸びしろ" dataKey="growth" stroke={COLORS.radarGrowth} fill={COLORS.radarGrowth} fillOpacity={0.25} />
+                <Radar
+                  name="現在"
+                  dataKey="current"
+                  stroke={COLORS.radarCurrent}
+                  fill={COLORS.radarCurrent}
+                  fillOpacity={0.35}
+                />
+                <Radar
+                  name="伸びしろ"
+                  dataKey="growth"
+                  stroke={COLORS.radarGrowth}
+                  fill={COLORS.radarGrowth}
+                  fillOpacity={0.25}
+                />
                 <Legend />
               </RadarChart>
             </ResponsiveContainer>
@@ -247,7 +128,6 @@ export default function SkillsChart() {
 
         {/* 横型バー */}
         <section className="bg-white rounded-2xl shadow p-6 w-full lg:w-1/2">
-          
           <div className="w-full h-[640px]">
             <ResponsiveContainer width="100%" height="100%">
               <BarChart data={tools} layout="vertical" margin={{ top: 10, right: 20, bottom: 10, left: 150 }}>
@@ -264,12 +144,14 @@ export default function SkillsChart() {
             </ResponsiveContainer>
           </div>
           <div className="mt-4 flex flex-wrap items-center gap-4 text-sm">
-            <span className="inline-flex items-center gap-2"><span className="inline-block w-3 h-3 rounded bg-[#bb5555]"></span>使える（5）</span>
-            <span className="inline-flex items-center gap-2"><span className="inline-block w-3 h-3 rounded bg-[#008877]"></span>AIと一緒/学習中（2）</span>
+            <span className="inline-flex items-center gap-2">
+              <span className="inline-block w-3 h-3 rounded bg-[#bb5555]"></span>使える（5）
+            </span>
+            <span className="inline-flex items-center gap-2">
+              <span className="inline-block w-3 h-3 rounded bg-[#008877]"></span>AIと一緒/学習中（2）
+            </span>
           </div>
         </section>
-
-        
       </div>
     </div>
   );

--- a/src/data/skills.ts
+++ b/src/data/skills.ts
@@ -1,0 +1,135 @@
+export const SCORE = { STRONG: 5, ASSISTED: 2, FUTURE: 1 } as const;
+
+export interface SkillCategory {
+  key: string;
+  label: string;
+  current: number;
+  growth: number;
+}
+
+export interface SkillTool {
+  label: string;
+  cat: string;
+  level: number;
+}
+
+export interface StageSkillData {
+  categories: SkillCategory[];
+  tools: SkillTool[];
+}
+
+const currentCategories: SkillCategory[] = [
+  { key: "programming", label: "プログラミング", current: 4, growth: 5 },
+  { key: "architecture", label: "建築・設計", current: 5, growth: 4 },
+  { key: "design", label: "デザイン", current: 4, growth: 5 },
+  { key: "gis", label: "GIS・可視化", current: 5, growth: 4 },
+  { key: "office", label: "office365", current: 5, growth: 3 },
+  { key: "data", label: "データ分析", current: 2, growth: 5 },
+  { key: "realestate", label: "不動産", current: 5, growth: 4 },
+  { key: "finance", label: "金融", current: 4, growth: 5 },
+  { key: "dx", label: "DX/自動化", current: 3, growth: 5 },
+];
+
+const futureCategories: SkillCategory[] = [
+  { key: "marketing", label: "マーケティング", current: 3, growth: 5 },
+  { key: "pm", label: "プロジェクトマネジメント", current: 4, growth: 5 },
+  { key: "legal", label: "法務・コンプライアンス", current: 2, growth: 4 },
+  { key: "language", label: "語学", current: 3, growth: 4 },
+  { key: "communication", label: "コミュニケーション・プレゼン", current: 4, growth: 5 },
+  { key: "education", label: "教育・研修", current: 3, growth: 4 },
+  { key: "research", label: "リサーチ・分析", current: 4, growth: 5 },
+  { key: "innovation", label: "イノベーション/新規事業", current: 3, growth: 5 },
+  { key: "sustainability", label: "サステナビリティ/ESG", current: 2, growth: 5 },
+  { key: "customer", label: "顧客対応・CX", current: 1, growth: 1 },
+  { key: "training", label: "トレーニング・コーチング", current: 3, growth: 4 },
+];
+
+const currentTools: SkillTool[] = [
+  // プログラミング
+  { label: "Python", cat: "プログラミング", level: SCORE.STRONG },
+  { label: "JavaScript / TypeScript", cat: "プログラミング", level: SCORE.ASSISTED },
+  { label: "Node.js", cat: "プログラミング", level: SCORE.ASSISTED },
+  // 建築・設計
+  { label: "AutoCAD", cat: "建築・設計", level: SCORE.STRONG },
+  { label: "SketchUp", cat: "建築・設計", level: SCORE.STRONG },
+  { label: "Rhino + Grasshopper", cat: "建築・設計", level: SCORE.STRONG },
+  { label: "Twinmotion", cat: "建築・設計", level: SCORE.STRONG },
+  { label: "Lumion", cat: "建築・設計", level: SCORE.ASSISTED },
+  // デザイン
+  { label: "Adobe Illustrator", cat: "デザイン", level: SCORE.STRONG },
+  { label: "Adobe Photoshop", cat: "デザイン", level: SCORE.STRONG },
+  { label: "Blender", cat: "デザイン", level: SCORE.ASSISTED },
+  { label: "Inkscape", cat: "デザイン", level: SCORE.ASSISTED },
+  { label: "DaVinci Resolve", cat: "デザイン", level: SCORE.ASSISTED },
+  // GIS
+  { label: "ArcGIS", cat: "GIS・可視化", level: SCORE.STRONG },
+  { label: "QGIS", cat: "GIS・可視化", level: SCORE.STRONG },
+  { label: "Kepler.gl", cat: "GIS・可視化", level: SCORE.STRONG },
+  // office365
+  { label: "Excel", cat: "office365", level: SCORE.STRONG },
+  { label: "PowerPoint", cat: "office365", level: SCORE.STRONG },
+  // データ
+  { label: "Pandas", cat: "データ分析", level: SCORE.ASSISTED },
+  { label: "NumPy", cat: "データ分析", level: SCORE.ASSISTED },
+  // 不動産
+  { label: "土地仕入・ボリューム検討", cat: "不動産", level: SCORE.STRONG },
+  { label: "事業収支/DCF（Excel）", cat: "不動産", level: SCORE.STRONG },
+  { label: "不動産証券化の基礎", cat: "不動産", level: SCORE.ASSISTED },
+  // 金融
+  { label: "DCF/NPV・IRR", cat: "金融", level: SCORE.STRONG },
+  { label: "LTV/DSCR", cat: "金融", level: SCORE.ASSISTED },
+  // DX
+  { label: "業務自動化（Python+Excel）", cat: "DX/自動化", level: SCORE.ASSISTED },
+  { label: "ダッシュボード試作（Kepler/BI）", cat: "DX/自動化", level: SCORE.ASSISTED },
+];
+
+const futureTools: SkillTool[] = [
+  // マーケティング
+  { label: "Webマーケティング", cat: "マーケティング", level: SCORE.ASSISTED },
+  { label: "SEO・SNS運用", cat: "マーケティング", level: SCORE.ASSISTED },
+  { label: "広告運用(Google/Facebook)", cat: "マーケティング", level: SCORE.ASSISTED },
+  // PM
+  { label: "進行管理", cat: "プロジェクトマネジメント", level: SCORE.STRONG },
+  { label: "チームマネジメント", cat: "プロジェクトマネジメント", level: SCORE.STRONG },
+  { label: "アジャイル開発管理", cat: "プロジェクトネジメント", level: 3 },
+  // 法務
+  { label: "契約・建築法務", cat: "法務・コンプライアンス", level: SCORE.ASSISTED },
+  { label: "都市計画法/建築基準法", cat: "法務・コンプライアンス", level: SCORE.ASSISTED },
+  // 語学
+  { label: "英語業務対応", cat: "語学", level: 3 },
+  { label: "ビジネス英語メール", cat: "語学", level: 3 },
+  // コミュニケーション
+  { label: "プレゼンテーション", cat: "コミュニケーション・プレゼン", level: SCORE.STRONG },
+  { label: "ファシリテーション", cat: "コミュニケーション・プレゼン", level: SCORE.STRONG },
+  // 教育
+  { label: "社内研修講師", cat: "教育・研修", level: 3 },
+  { label: "外部セミナー登壇", cat: "教育・研修", level: SCORE.ASSISTED },
+  // リサーチ
+  { label: "市場調査・競合分析", cat: "リサーチ・分析", level: SCORE.STRONG },
+  { label: "ユーザーインタビュー", cat: "リサーチ・分析", level: 3 },
+  // 新規事業
+  { label: "事業アイデア創出", cat: "イノベーション/新規事業", level: 3 },
+  { label: "PoC企画・実施", cat: "イノベーション/新規事業", level: 3 },
+  // ESG
+  { label: "ESGレポート作成", cat: "サステナビリティ/ESG", level: SCORE.ASSISTED },
+  { label: "環境配慮設計", cat: "サステナビリティ/ESG", level: SCORE.ASSISTED },
+  // CX
+  { label: "顧客満足度分析", cat: "顧客対応・CX", level: 1 },
+  { label: "カスタマーサクセス運用", cat: "顧客対応・CX", level: 3 },
+  // トレーニング
+  { label: "1on1コーチング", cat: "トレーニング・コーチング", level: 3 },
+  { label: "キャリア面談", cat: "トレーニング・コーチング", level: 3 },
+];
+
+export const careerStages = [
+  { key: "current", label: "現在" },
+  { key: "future", label: "将来" },
+] as const;
+
+export type CareerStageKey = typeof careerStages[number]["key"];
+
+export const skillsByStage: Record<CareerStageKey, StageSkillData> = {
+  current: { categories: currentCategories, tools: currentTools },
+  future: { categories: futureCategories, tools: futureTools },
+};
+


### PR DESCRIPTION
## Summary
- group skill categories and tools into stage-based collections
- allow About page to select a career stage and pass its skill data to SkillsChart
- compute radar and bar chart data from provided stage info

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ff623e3e483289527c6f428f5bd11