### PR TITLE
feat: enhance works page with tag filtering

### DIFF
--- a/src/app/works/page.tsx
+++ b/src/app/works/page.tsx
@@ -1,5 +1,6 @@
 
 import React from 'react';
+import Link from 'next/link';
 import WorkCard from '@/components/WorkCard';
 import worksData from '../../../materials/works.json';
 
@@ -12,11 +13,39 @@ const WorksPage: React.FC<WorksPageProps> = ({ searchParams }) => {
   const filteredWorks = tag
     ? worksData.filter((work) => work.tags?.includes(tag))
     : worksData;
+  const allTags = Array.from(
+    new Set(worksData.flatMap((work) => work.tags || []))
+  );
   return (
     <div className="min-h-screen bg-white text-gray-900 p-8">
       <h1 className="text-5xl font-extrabold mb-12 mt-24 text-center">
         Works{tag ? `: ${tag}` : ''}
       </h1>
+      <div className="flex justify-center flex-wrap gap-4 mb-12">
+        <Link
+          href="/works"
+          className={`px-4 py-2 rounded ${
+            !tag
+              ? 'bg-gray-900 text-white'
+              : 'bg-gray-200 text-gray-900'
+          }`}
+        >
+          All
+        </Link>
+        {allTags.map((t) => (
+          <Link
+            key={t}
+            href={`/works?tag=${t}`}
+            className={`px-4 py-2 rounded ${
+              tag === t
+                ? 'bg-gray-900 text-white'
+                : 'bg-gray-200 text-gray-900'
+            }`}
+          >
+            {t}
+          </Link>
+        ))}
+      </div>
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-2 gap-8">
         {filteredWorks.map((work) => (
           <WorkCard
@@ -26,6 +55,7 @@ const WorksPage: React.FC<WorksPageProps> = ({ searchParams }) => {
             description={work.description}
             monochromeImage={work.monochromeImage}
             colorImage={work.colorImage}
+            tags={work.tags}
           />
         ))}
       </div>

--- a/src/components/WorkCard.tsx
+++ b/src/components/WorkCard.tsx
@@ -10,6 +10,7 @@ interface WorkCardProps {
   description: string;
   monochromeImage: string;
   colorImage: string;
+  tags?: string[];
 }
 
 const WorkCard: React.FC<WorkCardProps> = ({
@@ -18,33 +19,47 @@ const WorkCard: React.FC<WorkCardProps> = ({
   description,
   monochromeImage,
   colorImage,
+  tags = [],
 }) => {
   const [isHovered, setIsHovered] = useState(false);
 
   return (
-    <Link href={`/works/${id}`}>
-      <div
-        className="relative rounded-lg shadow-lg overflow-hidden cursor-pointer group"
-        onMouseEnter={() => setIsHovered(true)}
-        onMouseLeave={() => setIsHovered(false)}
-      >
-        <div className="relative w-full h-64 overflow-hidden mb-4">
-          <Image
-            src={isHovered ? colorImage : monochromeImage}
-            alt={title}
-            layout="fill"
-            objectFit="cover"
-            className="transition-transform duration-500 ease-in-out group-hover:scale-110"
-          />
-        </div>
+    <div>
+      <Link href={`/works/${id}`}>
         <div
-          className="p-4 pt-8 bg-white"
+          className="relative rounded-lg shadow-lg overflow-hidden cursor-pointer group"
+          onMouseEnter={() => setIsHovered(true)}
+          onMouseLeave={() => setIsHovered(false)}
         >
-          <h2 className="text-2xl font-bold mb-2 text-gray-900">{title}</h2>
-          <p className="text-gray-700">{description}</p>
+          <div className="relative w-full h-64 overflow-hidden">
+            <Image
+              src={isHovered ? colorImage : monochromeImage}
+              alt={title}
+              layout="fill"
+              objectFit="cover"
+              className="transition-transform duration-500 ease-in-out group-hover:scale-110"
+            />
+          </div>
         </div>
+      </Link>
+      <div className="mt-4">
+        <h2 className="text-2xl font-bold mb-2 text-gray-900">{title}</h2>
+        <p className="text-gray-700">{description}</p>
+        {tags.length > 0 && (
+          <div className="mt-2 flex flex-wrap gap-2">
+            {tags.map((tag) => (
+              <Link
+                key={tag}
+                href={`/works?tag=${tag}`}
+                className="text-sm text-blue-600 hover:underline"
+              >
+                #{tag}
+              </Link>
+            ))}
+          </div>
+        )}
       </div>
-    </Link>
+    </div>
   );
 };
 


### PR DESCRIPTION
## Summary
- separate work card text from image and show tags
- add tag filter controls on works page

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ff7981a7c83288c4f0cd535b95bdf