### PR TITLE
Add detailed work pages with custom styling

### DIFF
--- a/materials/works.json
+++ b/materials/works.json
@@ -5,6 +5,7 @@
     "description": "This is a description for Project Alpha. It showcases innovative design and engineering principles.",
     "monochromeImage": "/images/film_bw_1.jpg",
     "colorImage": "/images/film_color_1.jpg",
+    "bgColor": "#e9d5ff",
     "tags": ["data-analysis"]
   },
   {
@@ -13,6 +14,7 @@
     "description": "A deep dive into sustainable architecture and urban planning.",
     "monochromeImage": "/images/film_bw_1.jpg",
     "colorImage": "/images/film_color_1.jpg",
+    "bgColor": "#fde68a",
     "tags": ["design-programming"]
   },
   {
@@ -21,6 +23,7 @@
     "description": "Exploring the intersection of traditional craftsmanship and modern technology.",
     "monochromeImage": "/images/film_bw_1.jpg",
     "colorImage": "/images/film_color_1.jpg",
+    "bgColor": "#bae6fd",
     "tags": ["artificial-intelligence"]
   },
   {
@@ -29,6 +32,7 @@
     "description": "A study on material science and its application in structural design.",
     "monochromeImage": "/images/film_bw_1.jpg",
     "colorImage": "/images/film_color_1.jpg",
+    "bgColor": "#bbf7d0",
     "tags": ["data-analysis"]
   },
   {
@@ -37,6 +41,7 @@
     "description": "Innovative solutions for compact living spaces in urban environments.",
     "monochromeImage": "/images/film_bw_1.jpg",
     "colorImage": "/images/film_color_1.jpg",
+    "bgColor": "#fecaca",
     "tags": ["design-programming"]
   },
   {
@@ -45,6 +50,7 @@
     "description": "A conceptual project focusing on future city infrastructure.",
     "monochromeImage": "/images/film_bw_1.jpg",
     "colorImage": "/images/film_color_1.jpg",
+    "bgColor": "#fbcfe8",
     "tags": ["artificial-intelligence"]
   }
 ]

--- a/src/app/works/[id]/page.tsx
+++ b/src/app/works/[id]/page.tsx
@@ -1,19 +1,72 @@
 // src/app/works/[id]/page.tsx
-import type { Metadata } from "next";
+import Image from 'next/image';
+import { notFound } from 'next/navigation';
+import type { Metadata } from 'next';
+import works from '../../../../materials/works.json';
+
+type Work = {
+  id: string;
+  title: string;
+  description: string;
+  monochromeImage: string;
+  colorImage: string;
+  bgColor?: string;
+};
 
 type PageProps = { params: { id: string } };
 
+export function generateStaticParams() {
+  return (works as Work[]).map((work) => ({ id: work.id }));
+}
+
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const id = decodeURIComponent(params.id);
-  return { title: `Works | ${id}`, description: `Work detail for "${id}"` };
+  const work = (works as Work[]).find((w) => w.id === id);
+  if (!work) {
+    return { title: 'Work not found' };
+  }
+  return {
+    title: work.title,
+    description: work.description,
+  };
 }
 
 export default function WorkPage({ params }: PageProps) {
   const id = decodeURIComponent(params.id);
+  const work = (works as Work[]).find((w) => w.id === id);
+
+  if (!work) {
+    notFound();
+  }
+
   return (
-    <main className="max-w-4xl mx-auto px-4 py-10">
-      <h1 className="text-3xl font-bold mb-4">Work: {id}</h1>
-      <p className="text-gray-600">ここに作品「{id}」の詳細を表示します。</p>
+    <main
+      className="min-h-screen text-gray-900"
+      style={{ backgroundColor: work.bgColor }}
+    >
+      <div className="max-w-6xl mx-auto px-6 py-16 flex flex-col md:flex-row items-center gap-10">
+        <div className="flex-1">
+          <h1 className="text-4xl font-bold mb-6">{work.title}</h1>
+          <p className="text-lg leading-relaxed">{work.description}</p>
+        </div>
+        <div className="flex-1 relative w-full h-96">
+          <Image
+            src={work.colorImage}
+            alt={work.title}
+            fill
+            className="object-cover rounded-lg shadow-lg"
+          />
+          <div className="hidden md:block absolute -left-10 bottom-0 w-40 h-40">
+            <Image
+              src={work.monochromeImage}
+              alt=""
+              fill
+              className="object-cover rounded-md shadow-md"
+            />
+          </div>
+        </div>
+      </div>
     </main>
   );
 }
+


### PR DESCRIPTION
## Summary
- add background colors for each work in data
- create dynamic work detail page showing title, description, and images

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0b957767c83288bf62ae5270a72a1