### PR TITLE
Use optimized image assets

### DIFF
--- a/src/app/api/images/route.ts
+++ b/src/app/api/images/route.ts
@@ -1,9 +1,12 @@
 import { NextResponse } from 'next/server';
 import manifest from './manifest.json';
+import { optimizedImage } from '@/lib/optimizedImage';
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const keyword = searchParams.get('keyword') ?? '';
   const matched = manifest.filter((file) => file.includes(keyword));
-  return NextResponse.json(matched.map((file) => `/images/${file}`));
+  return NextResponse.json(
+    matched.map((file) => optimizedImage(`/images/${file}`, { type: 'thumbs', width: 480 }))
+  );
 }

--- a/src/app/works/page.tsx
+++ b/src/app/works/page.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import Link from 'next/link';
 import WorkCard from '@/components/WorkCard';
 import worksData from '../../../materials/works.json';
+import { optimizedImage } from '@/lib/optimizedImage';
 
 interface WorksPageProps {
   searchParams: { tag?: string };
@@ -53,8 +54,8 @@ const WorksPage: React.FC<WorksPageProps> = ({ searchParams }) => {
             id={work.id}
             title={work.title}
             description={work.description}
-            monochromeImage={work.monochromeImage}
-            colorImage={work.colorImage}
+            monochromeImage={optimizedImage(work.monochromeImage)}
+            colorImage={optimizedImage(work.colorImage)}
             tags={work.tags}
           />
         ))}

--- a/src/components/InterestsSection.tsx
+++ b/src/components/InterestsSection.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { motion, useInView, useScroll, useTransform } from 'framer-motion';
 import { useEffect, useRef, useState } from 'react';
+import { optimizedImage } from '@/lib/optimizedImage';
 
 const slugify = (text: string) =>
   text
@@ -20,49 +21,49 @@ const interests = {
     {
       title: 'Real Estate',
       description: '空間の価値を捉え、未来の可能性を創造する。',
-      imageUrl: '/images/building_osaka.jpg',
+      imageUrl: optimizedImage('/images/building_osaka.jpg'),
     },
     {
       title: 'Architecture',
       description: '機能と美が融合した、心地よい空間を追求する。',
-      imageUrl: '/images/drawing_aris.jpg',
+      imageUrl: optimizedImage('/images/drawing_aris.jpg'),
     },
     {
       title: 'Living',
       description: '日々の営みを豊かにする、ささやかな工夫と発見。',
-      imageUrl: '/images/kurashi.jpg',
+      imageUrl: optimizedImage('/images/kurashi.jpg'),
     },
     {
       title: 'Crafting',
       description: '手を動かし、思考を形にする創造の喜び。',
-      imageUrl: '/images/me_mad.jpg',
+      imageUrl: optimizedImage('/images/me_mad.jpg'),
     },
   ],
   cultureAndExploration: [
     {
       title: 'Photography',
       description: '光と影で切り取る、世界の美しい瞬間。',
-      imageUrl: '/images/film_bw_29.jpg',
+      imageUrl: optimizedImage('/images/film_bw_29.jpg'),
     },
     {
       title: 'Food',
       description: '文化、歴史、そして人との繋がりを味わう。',
-      imageUrl: '/images/food_me_tomato.jpg',
+      imageUrl: optimizedImage('/images/food_me_tomato.jpg'),
     },
     {
       title: 'Bonsai',
       description: '小さな鉢の中に、大自然の縮図を育む。',
-      imageUrl: '/images/bird.JPG',
+      imageUrl: optimizedImage('/images/bird.JPG'),
     },
     {
       title: 'Calligraphy',
       description: '墨と筆で描く、静寂と躍動。',
-      imageUrl: '/images/syodo_ko.jpg',
+      imageUrl: optimizedImage('/images/syodo_ko.jpg'),
     },
     {
       title: 'Travel',
       description: '未知の風景と文化に触れる、自己発見の冒険。',
-      imageUrl: '/images/trip_kumano_3.jpg',
+      imageUrl: optimizedImage('/images/trip_kumano_3.jpg'),
     },
   ],
   digital: [
@@ -74,12 +75,12 @@ const interests = {
     {
       title: 'Design × Programming',
       description: '美しさと使いやすさを追求し、情報を最適に届ける。',
-      imageUrl: '/images/web_pavillion.PNG',
+      imageUrl: optimizedImage('/images/web_pavillion.PNG'),
     },
     {
       title: 'Artificial Intelligence',
       description: '正直、作業はこいつ任せだぜ、相棒。',
-      imageUrl: '/images/ai_girl_1.png',
+      imageUrl: optimizedImage('/images/ai_girl_1.png'),
     },
   ],
 };

--- a/src/components/PhotosClientPage.tsx
+++ b/src/components/PhotosClientPage.tsx
@@ -4,6 +4,7 @@ import { useState, useRef, useEffect, useCallback } from 'react';
 import Image from 'next/image';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useScrollbarWidth } from '@/context/ScrollbarWidthContext';
+import { optimizedImage } from '@/lib/optimizedImage';
 
 interface Photo {
   src: string;
@@ -11,7 +12,7 @@ interface Photo {
   dominantBgColor: string; // Background color for modal
 }
 
-const initialPhotos: Photo[] = [
+const rawPhotos: Photo[] = [
   { src: '/images/trip_eu_1.jpg', alt: 'Europe Trip 1', dominantBgColor: '#ADD8E6' },
   { src: '/images/trip_eu_2.jpg', alt: 'Europe Trip 2', dominantBgColor: '#ADD8E6' },
   { src: '/images/trip_eu_3.jpg', alt: 'Europe Trip 3', dominantBgColor: '#ADD8E6' },
@@ -67,6 +68,8 @@ const initialPhotos: Photo[] = [
   { src: '/images/film_color_14.jpg', alt: 'Color Film 14', dominantBgColor: '#32CD32' },
   { src: '/images/film_color_15.jpg', alt: 'Color Film 15', dominantBgColor: '#32CD32' },
 ];
+
+const initialPhotos: Photo[] = rawPhotos.map((p) => ({ ...p, src: optimizedImage(p.src) }));
 
 export default function PhotosClientPage() {
   const { scrollbarWidth } = useScrollbarWidth();

--- a/src/components/WorkDetailClient.tsx
+++ b/src/components/WorkDetailClient.tsx
@@ -3,6 +3,7 @@
 import Image from 'next/image';
 import { motion } from 'framer-motion';
 import { useSearchParams } from 'next/navigation';
+import { optimizedImage } from '@/lib/optimizedImage';
 
 interface WorkDetailClientProps {
   workId: string;
@@ -23,12 +24,12 @@ const dummyWorkData = {
     この建築は、単なる構造物ではなく、未来の都市生活のあり方を提案するものです。
   `,
   images: [
-    '/images/image_ginza_1.png',
-    '/images/image_ginza_2.png',
-    '/images/image_ginza_3.png',
-    '/images/image_ginza_4.png',
-    '/images/building_osaka.jpg',
-    '/images/drawing_plantbuilding.png',
+    optimizedImage('/images/image_ginza_1.png'),
+    optimizedImage('/images/image_ginza_2.png'),
+    optimizedImage('/images/image_ginza_3.png'),
+    optimizedImage('/images/image_ginza_4.png'),
+    optimizedImage('/images/building_osaka.jpg'),
+    optimizedImage('/images/drawing_plantbuilding.png'),
   ],
 };
 

--- a/src/lib/optimizedImage.ts
+++ b/src/lib/optimizedImage.ts
@@ -1,0 +1,13 @@
+export type OptimizedOptions = {
+  type?: 'display' | 'thumbs';
+  width?: number;
+  format?: 'avif' | 'webp';
+};
+
+export function optimizedImage(
+  src: string,
+  { type = 'display', width = 1200, format = 'webp' }: OptimizedOptions = {}
+): string {
+  const base = src.replace(/^\/images\//, '').replace(/\.[^.]+$/, '');
+  return `/optimized/${type}/${base}-${width}.${format}`;
+}


### PR DESCRIPTION
## Summary
- add `optimizedImage` helper to point to pre-generated low-res images in `public/optimized`
- update components and API to load images via `optimizedImage`
- switch Works page thumbnails to optimized sources
- keep Gomoku hero image at full resolution

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0bbf1c4e48328b5cb835cf4b8c80b