### PR TITLE
feat: add horizontal scroll to work page

### DIFF
--- a/src/app/works/[id]/WorkContent.tsx
+++ b/src/app/works/[id]/WorkContent.tsx
@@ -1,0 +1,46 @@
+// src/app/works/[id]/WorkContent.tsx
+'use client';
+
+import Image from 'next/image';
+import BackButton from '@/components/BackButton';
+import useHorizontalScroll from '@/hooks/useHorizontalScroll';
+
+export type Work = {
+  id: string;
+  title: string;
+  description: string;
+  monochromeImage: string;
+  colorImage: string;
+  images?: string[];
+  bgColor?: string;
+};
+
+interface WorkContentProps {
+  work: Work;
+  images: string[];
+}
+
+export default function WorkContent({ work, images }: WorkContentProps) {
+  const scrollRef = useHorizontalScroll<HTMLDivElement>();
+
+  return (
+    <main
+      ref={scrollRef}
+      className="relative flex h-screen w-screen overflow-x-auto overflow-y-hidden text-gray-900"
+      style={{ backgroundColor: work.bgColor }}
+    >
+      <BackButton />
+      <div className="flex-shrink-0 h-full w-[40vw] flex items-center p-8">
+        <div className="max-w-md text-left">
+          <h1 className="text-4xl font-bold mb-6">{work.title}</h1>
+          <p className="text-lg leading-relaxed">{work.description}</p>
+        </div>
+      </div>
+      {images.map((src, idx) => (
+        <div key={idx} className="relative flex-shrink-0 h-full w-[60vw]">
+          <Image src={src} alt={idx === 0 ? work.title : ''} fill className="object-cover" />
+        </div>
+      ))}
+    </main>
+  );
+}

--- a/src/app/works/[id]/page.tsx
+++ b/src/app/works/[id]/page.tsx
@@ -1,19 +1,9 @@
 // src/app/works/[id]/page.tsx
-import Image from 'next/image';
 import { notFound } from 'next/navigation';
 import type { Metadata } from 'next';
 import works from '../../../../materials/works.json';
-import BackButton from '@/components/BackButton';
-
-type Work = {
-  id: string;
-  title: string;
-  description: string;
-  monochromeImage: string;
-  colorImage: string;
-  images?: string[];
-  bgColor?: string;
-};
+import WorkContent from './WorkContent';
+import type { Work } from './WorkContent';
 
 type PageProps = { params: { id: string } };
 
@@ -46,24 +36,6 @@ export default function WorkPage({ params }: PageProps) {
       ? work.images
       : [work.colorImage, work.monochromeImage].filter(Boolean);
 
-  return (
-    <main
-      className="relative flex h-screen w-screen overflow-x-auto overflow-y-hidden text-gray-900"
-      style={{ backgroundColor: work.bgColor }}
-    >
-      <BackButton />
-      <div className="flex-shrink-0 h-full w-[40vw] flex items-center p-8">
-        <div className="max-w-md text-left">
-          <h1 className="text-4xl font-bold mb-6">{work.title}</h1>
-          <p className="text-lg leading-relaxed">{work.description}</p>
-        </div>
-      </div>
-      {images.map((src, idx) => (
-        <div key={idx} className="relative flex-shrink-0 h-full w-[60vw]">
-          <Image src={src} alt={idx === 0 ? work.title : ''} fill className="object-cover" />
-        </div>
-      ))}
-    </main>
-  );
+  return <WorkContent work={work} images={images} />;
 }
 

--- a/src/hooks/useHorizontalScroll.ts
+++ b/src/hooks/useHorizontalScroll.ts
@@ -1,0 +1,26 @@
+// src/hooks/useHorizontalScroll.ts
+'use client';
+
+import { useRef, useEffect } from 'react';
+
+export default function useHorizontalScroll<T extends HTMLElement>() {
+  const containerRef = useRef<T>(null);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+
+    const onWheel = (e: WheelEvent) => {
+      if (e.deltaY === 0) return;
+      e.preventDefault();
+      el.scrollBy({ left: e.deltaY, behavior: 'smooth' });
+    };
+
+    el.addEventListener('wheel', onWheel, { passive: false });
+    return () => {
+      el.removeEventListener('wheel', onWheel);
+    };
+  }, []);
+
+  return containerRef;
+}

--- a/src/hooks/useHorizontalScroll.ts
+++ b/src/hooks/useHorizontalScroll.ts
@@ -10,10 +10,12 @@ export default function useHorizontalScroll<T extends HTMLElement>() {
     const el = containerRef.current;
     if (!el) return;
 
+    const SCROLL_MULTIPLIER = 3; // amplify scroll distance per wheel event
+
     const onWheel = (e: WheelEvent) => {
       if (e.deltaY === 0) return;
       e.preventDefault();
-      el.scrollBy({ left: e.deltaY, behavior: 'smooth' });
+      el.scrollBy({ left: e.deltaY * SCROLL_MULTIPLIER, behavior: 'smooth' });
     };
 
     el.addEventListener('wheel', onWheel, { passive: false });


### PR DESCRIPTION
## Summary
- add hook to translate vertical wheel events into horizontal scroll
- display work detail content in a horizontally scrollable layout
- integrate client component on work detail page

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1372d7af8832886716bbd9f8b1a91