### PR TITLE
Keep Arts & Culture background static

### DIFF
--- a/src/components/InterestsSection.tsx
+++ b/src/components/InterestsSection.tsx
@@ -225,8 +225,6 @@ export default function InterestsSection() {
   const { scrollYProgress } = useScroll({ target: containerRef, offset: ['start end', 'end start'] });
   const pathLength = useTransform(scrollYProgress, [0, 0.85], [0, 1]);
 
-  const { scrollYProgress: scrollYProgressCulture } = useScroll({ target: cultureRef, offset: ["start end", "end start"] });
-  const backgroundYCulture = useTransform(scrollYProgressCulture, [0, 1], ["-100%", "100%"]);
 
   const [imagePools, setImagePools] = useState<Record<string, string[]>>({
     'Data Analysis': [],
@@ -598,7 +596,7 @@ return (
           backgroundImage: 'url("/images/asanoha.svg")',
           backgroundSize: '140px 80px',
           backgroundRepeat: 'repeat',
-          backgroundPositionY: backgroundYCulture,
+          backgroundAttachment: 'fixed',
         }}
       >
         <div className="pointer-events-none absolute inset-x-0 top-0 h-16 bg-gradient-to-b from-white to-transparent" />


### PR DESCRIPTION
## Summary
- keep Arts & Culture background fixed during scroll by removing scroll-based position and using CSS background attachment

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a148199bbc8328858895c9201e6d04