### PR TITLE
Fix mobile hero tagline wrapping and line pattern scaling

### DIFF
--- a/public/images/asanoha.svg
+++ b/public/images/asanoha.svg
@@ -1,3 +1,3 @@
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="70" height="40" viewBox="0 0 140 80" preserveAspectRatio="xMidYMid meet">
-<path fill="none" stroke="#bb5555" stroke-width="1.7" opacity=".31" vector-effect="non-scaling-stroke" d="M47 0h-47v80h47l46-80h47v80h-47zM117 40h-94l-23 40l140-80-23 40 23 40-140-80 23 40M70-5v90"/>
+<path fill="none" stroke="#bb5555" stroke-width="1.7" opacity=".15" vector-effect="non-scaling-stroke" d="M47 0h-47v80h47l46-80h47v80h-47zM117 40h-94l-23 40l140-80-23 40 23 40-140-80 23 40M70-5v90"/>
 </svg>

--- a/public/images/asanoha.svg
+++ b/public/images/asanoha.svg
@@ -1,3 +1,3 @@
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="70" height="40" viewBox="0 0 140 80" preserveAspectRatio="none">
-<path fill="none" stroke="#bb5555" stroke-width="1.7" opacity=".31" d="M47 0h-47v80h47l46-80h47v80h-47zM117 40h-94l-23 40l140-80-23 40 23 40-140-80 23 40M70-5v90"/>
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="70" height="40" viewBox="0 0 140 80" preserveAspectRatio="xMidYMid meet">
+<path fill="none" stroke="#bb5555" stroke-width="1.7" opacity=".31" vector-effect="non-scaling-stroke" d="M47 0h-47v80h47l46-80h47v80h-47zM117 40h-94l-23 40l140-80-23 40 23 40-140-80 23 40M70-5v90"/>
 </svg>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -41,9 +41,9 @@ export default function Home() {
           {/* Main Catchphrase - Simple and Clean */}
           <div className="flex justify-center items-center">
             <h1
-              className="text-white text-6xl md:text-6xl font-light tracking-wider"
+              className="text-white text-4xl md:text-6xl font-light tracking-wider whitespace-nowrap"
               style={{ fontFamily: '"Shippori Mincho", serif' }}>
-              　ぼくは、五目飯。
+              ぼくは、五目飯。
             </h1>
           </div>
         </motion.div>

--- a/src/components/InterestsSection.tsx
+++ b/src/components/InterestsSection.tsx
@@ -537,7 +537,7 @@ return (
       <motion.svg
         className="absolute inset-0 w-full h-full pointer-events-none"
         viewBox="0 0 1000 3000"
-        preserveAspectRatio="none"
+        preserveAspectRatio="xMidYMid slice"
       >
         <motion.path
           d="M800 0 C100 400 400 800 1000 1200 S800 200 500 2000 100 100"
@@ -545,6 +545,7 @@ return (
           stroke="#008877"
           strokeWidth="56"
           strokeLinecap="round"
+          vectorEffect="non-scaling-stroke"
           style={{ pathLength }}
         />
         <motion.path
@@ -553,6 +554,7 @@ return (
           stroke="#bb5555"
           strokeWidth="56"
           strokeLinecap="round"
+          vectorEffect="non-scaling-stroke"
           style={{ pathLength }}
         />
       </motion.svg>

--- a/src/components/InterestsSection.tsx
+++ b/src/components/InterestsSection.tsx
@@ -198,7 +198,10 @@ const TypingCodeBackground: React.FC<TypingCodeBackgroundProps> = ({ snippets, p
   }, [isAnimating, snippets]);
 
   return (
-    <div className="absolute overflow-hidden pointer-events-none z-20 opacity-100 flex flex-col p-2 rounded-lg" style={position}>
+    <div
+      className="absolute overflow-hidden pointer-events-none z-0 opacity-100 flex flex-col p-2 rounded-lg"
+      style={position}
+    >
       {snippets.map((_, i) => (
         <pre key={i} className="text-white font-mono text-sm md:text-base whitespace-pre-wrap">
           {displayed[i] || ''}


### PR DESCRIPTION
## Summary
- keep hero catchphrase on a single line on small screens
- prevent cultural section's asanoha line pattern from distorting during scaling

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1f59f19948328a5d817a82e56b6cf