### PR TITLE
Ensure door animation covers initial load

### DIFF
--- a/src/components/ClientLayout.tsx
+++ b/src/components/ClientLayout.tsx
@@ -10,7 +10,9 @@ import { CursorProvider } from '@/context/CursorContext';
 import { ScrollbarWidthProvider } from '@/context/ScrollbarWidthContext';
 
 const CustomCursor = dynamic(() => import("@/components/CustomCursor"), { ssr: false });
-const LoadingScreen = dynamic(() => import('@/components/LoadingScreen'), { ssr: false });
+// Render the loading screen on the server to avoid a flash of the underlying page
+// before the doors animation appears on first load
+import LoadingScreen from '@/components/LoadingScreen';
 const ShadowAnimation = dynamic(() => import('./ShadowAnimation'), { ssr: false });
 
 interface ClientLayoutProps {


### PR DESCRIPTION
## Summary
- render the loading screen on the server so the door animation is visible immediately

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a90d5824b88328b33e60bab2b26ed6