### PR TITLE
Simplify works page animation and back button placement

### DIFF
--- a/src/components/BackButton.tsx
+++ b/src/components/BackButton.tsx
@@ -7,7 +7,7 @@ export default function BackButton() {
   return (
     <button
       onClick={() => router.back()}
-      className="absolute top-4 left-4 z-10 rounded-full bg-white/70 px-3 py-2 text-sm hover:bg-white"
+      className="absolute bottom-4 left-4 z-10 rounded-full bg-white/70 px-3 py-2 text-sm hover:bg-white"
     >
       ← Back
     </button>

--- a/src/components/ClientLayout.tsx
+++ b/src/components/ClientLayout.tsx
@@ -55,7 +55,7 @@ export default function ClientLayout({ children }: ClientLayoutProps) {
               key={pathname}
               initial={
                 isWorksRelatedPage
-                  ? { opacity: 0, x: '100%' }
+                  ? { opacity: 0, x: 20 }
                   : { opacity: 0, y: 20 }
               }
               animate={
@@ -65,10 +65,10 @@ export default function ClientLayout({ children }: ClientLayoutProps) {
               }
               exit={
                 isWorksRelatedPage
-                  ? { opacity: 0, x: '-100%' }
+                  ? { opacity: 0, x: -20 }
                   : { opacity: 0, y: -20 }
               }
-              transition={{ duration: 0.3, ease: 'easeInOut' }}
+              transition={{ duration: 0.2, ease: 'easeInOut' }}
               className={textColor} // textColor を main にも適用
             >
               {children}


### PR DESCRIPTION
## Summary
- Move work detail page back button to the bottom left corner
- Simplify slide animation for works-related pages with minimal horizontal movement

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a90d84d8748328a2bee31db18d4951