### PR TITLE
Remove transition animations causing page flicker

### DIFF
--- a/src/app/template.tsx
+++ b/src/app/template.tsx
@@ -1,29 +1,5 @@
-'use client';
-
-import { motion, AnimatePresence } from 'framer-motion';
-import { usePathname } from 'next/navigation';
+"use client";
 
 export default function Template({ children }: { children: React.ReactNode }) {
-  const pathname = usePathname();
-
-  const variants = {
-    hidden: { opacity: 0, x: "100%" },
-    enter: { opacity: 1, x: "0%" },
-    exit: { opacity: 0, x: "-100%" },
-  };
-
-  return (
-    <AnimatePresence mode="wait" initial={false}>
-      <motion.div
-        key={pathname}
-        variants={variants}
-        initial="hidden"
-        animate="enter"
-        exit="exit"
-        transition={{ type: 'tween', duration: 0.6, ease: 'easeInOut' }}
-      >
-        {children}
-      </motion.div>
-    </AnimatePresence>
-  );
+  return <>{children}</>;
 }

--- a/src/components/ClientLayout.tsx
+++ b/src/components/ClientLayout.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { AnimatePresence, motion } from 'framer-motion';
 import { usePathname } from 'next/navigation';
 import { useState, useEffect } from 'react';
 import Header from "@/components/Header";
@@ -22,19 +21,11 @@ interface ClientLayoutProps {
 export default function ClientLayout({ children }: ClientLayoutProps) {
   const pathname = usePathname();
   const [isLoading, setIsLoading] = useState(true);
-  const isHomePage = pathname === '/';
   const isWorkDetailPage = pathname.startsWith('/works/') && pathname !== '/works';
-  const isWorksRelatedPage = pathname.startsWith('/works');
 
   // 色の状態管理を ClientLayout に移動
   const [bgColor, setBgColor] = useState('bg-white');
   const [textColor, setTextColor] = useState('text-[#008877]');
-
-  // page.tsx から色の変更を受け取るためのコールバック関数
-  const handleColorChange = (newBgColor: string, newTextColor: string) => {
-    setBgColor(newBgColor);
-    setTextColor(newTextColor);
-  };
 
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -52,30 +43,9 @@ export default function ClientLayout({ children }: ClientLayoutProps) {
           <CustomCursor />
           {/* Header に textColor を渡す */}
           <Header textColor={textColor} />
-          <AnimatePresence mode="wait" initial={false}>
-            <motion.main
-              key={pathname}
-              initial={
-                isWorksRelatedPage
-                  ? { opacity: 0, x: 20 }
-                  : { opacity: 0, y: 20 }
-              }
-              animate={
-                isWorksRelatedPage
-                  ? { opacity: 1, x: 0 }
-                  : { opacity: 1, y: 0 }
-              }
-              exit={
-                isWorksRelatedPage
-                  ? { opacity: 0, x: -20 }
-                  : { opacity: 0, y: -20 }
-              }
-              transition={{ duration: 0.2, ease: 'easeInOut' }}
-              className={textColor} // textColor を main にも適用
-            >
-              {children}
-            </motion.main>
-          </AnimatePresence>
+          <main className={textColor}>
+            {children}
+          </main>
           
           {!isWorkDetailPage && (
             <ShadowAnimation>


### PR DESCRIPTION
## Summary
- remove global route transition wrapper to prevent flicker
- simplify client layout to render pages directly without motion effects

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a929bf48148328bec3b4f50aa4d0da