### PR TITLE
Improve mobile layout on landing page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -41,9 +41,10 @@ export default function Home() {
           {/* Main Catchphrase - Simple and Clean */}
           <div className="flex justify-center items-center">
             <h1
-              className="text-white text-6xl md:text-6xl font-light tracking-wider"
-              style={{ fontFamily: '"Shippori Mincho", serif' }}>
-              　ぼくは、五目飯。
+              className="text-white text-4xl sm:text-5xl md:text-6xl font-light tracking-normal md:tracking-wider whitespace-nowrap"
+              style={{ fontFamily: '"Shippori Mincho", serif' }}
+            >
+              ぼくは、五目飯。
             </h1>
           </div>
         </motion.div>

--- a/src/components/InterestsSection.tsx
+++ b/src/components/InterestsSection.tsx
@@ -560,15 +560,15 @@ return (
       {/* Space & Creation */}
       <section
         ref={spaceRef}
-        className="relative z-10 py-48 px-8 text-black"
+        className="relative z-10 py-24 md:py-48 px-8 text-black"
       >
-        <div className="grid md:grid-cols-3 gap-x-12 gap-y-8 mb-32 items-center max-w-6xl mx-auto w-full">
+        <div className="grid md:grid-cols-3 gap-x-12 gap-y-6 mb-16 md:gap-y-8 md:mb-32 items-center max-w-6xl mx-auto w-full">
           <motion.h3
             initial={{ opacity: 0, x: -40 }}
             whileInView={{ opacity: 1, x: 0 }}
             transition={{ duration: 0.8 }}
             viewport={{ once: true }}
-            className="md:col-span-1 text-5xl md:text-7xl font-bold"
+            className="md:col-span-1 text-4xl md:text-7xl font-bold"
             style={{}}
           >
             Space & Creation
@@ -591,7 +591,7 @@ return (
       {/* Culture and Exploration */}
       <motion.section
         ref={cultureRef}
-        className="relative flex flex-col justify-center px-8 py-48 bg-white text-[#bb5555]"
+        className="relative flex flex-col justify-center px-8 py-24 md:py-48 bg-white text-[#bb5555]"
         style={{
           backgroundImage: 'url("/images/asanoha.svg")',
           backgroundSize: '140px 80px',
@@ -601,13 +601,13 @@ return (
       >
         <div className="pointer-events-none absolute inset-x-0 top-0 h-16 bg-gradient-to-b from-white to-transparent" />
         <div className="pointer-events-none absolute inset-x-0 bottom-0 h-16 bg-gradient-to-t from-white to-transparent" />
-        <div className="grid md:grid-cols-3 gap-x-12 gap-y-8 mb-32 items-center max-w-6xl mx-auto">
+        <div className="grid md:grid-cols-3 gap-x-12 gap-y-6 mb-16 md:gap-y-8 md:mb-32 items-center max-w-6xl mx-auto">
           <motion.h3
             initial={{ opacity: 0, x: -40 }}
             whileInView={{ opacity: 1, x: 0 }}
             transition={{ duration: 0.8 }}
             viewport={{ once: true }}
-            className="md:col-span-1 text-5xl md:text-7xl font-bold"
+            className="md:col-span-1 text-4xl md:text-7xl font-bold"
             style={{}}
           >
             Arts & Culture


### PR DESCRIPTION
## Summary
- Ensure hero tagline fits on a single line in mobile view
- Tighten spacing and resize headings in "Space & Creation" and "Arts & Culture" sections for phones

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a941dd94608328999a26d9d123d479