### PR TITLE
Align gallery and contact pages with Works style

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -2,38 +2,35 @@ export default function Contact() {
   return (
     <main className="bg-[#ffffff] text-[#232024] py-20 px-8 md:px-16 lg:px-32 min-h-screen">
       <div className="max-w-3xl mx-auto">
-        <h1
-          className="text-4xl font-medium mb-24 text-center mt-24"
-          style={{ fontFamily: '"Shippori Mincho", serif' }}
-        >
-          お問い合わせ
+        <h1 className="text-5xl font-extrabold mb-24 text-center mt-24">
+          Contact
         </h1>
 
         {/* Contact Form Section */}
         <section className="mb-24 border border-gray-200/80 p-8 rounded-sm bg-white/50">
-          <h2 className="text-2xl font-bold mb-8 text-center" style={{ fontFamily: '"Shippori Mincho", serif' }}>
-            ご連絡はこちらから
+          <h2 className="text-2xl font-bold mb-8 text-center">
+            Feel free to reach out
           </h2>
           <form>
             <div className="mb-6">
-              <label htmlFor="name" className="block text-lg font-medium mb-2" style={{ fontFamily: '"Shippori Mincho", serif' }}>氏名</label>
+              <label htmlFor="name" className="block text-lg font-medium mb-2">Name</label>
               <input type="text" id="name" className="w-full p-3 border border-gray-300 rounded-sm focus:outline-none focus:border-[#b33953] transition-colors" />
             </div>
             <div className="mb-6">
-              <label htmlFor="email" className="block text-lg font-medium mb-2" style={{ fontFamily: '"Shippori Mincho", serif' }}>メールアドレス</label>
+              <label htmlFor="email" className="block text-lg font-medium mb-2">Email Address</label>
               <input type="email" id="email" className="w-full p-3 border border-gray-300 rounded-sm focus:outline-none focus:border-[#b33953] transition-colors" />
             </div>
             <div className="mb-6">
-              <label htmlFor="subject" className="block text-lg font-medium mb-2" style={{ fontFamily: '"Shippori Mincho", serif' }}>件名</label>
+              <label htmlFor="subject" className="block text-lg font-medium mb-2">Subject</label>
               <input type="text" id="subject" className="w-full p-3 border border-gray-300 rounded-sm focus:outline-none focus:border-[#b33953] transition-colors" />
             </div>
             <div className="mb-8">
-              <label htmlFor="message" className="block text-lg font-medium mb-2" style={{ fontFamily: '"Shippori Mincho", serif' }}>メッセージ</label>
+              <label htmlFor="message" className="block text-lg font-medium mb-2">Message</label>
               <textarea id="message" rows={7} className="w-full p-3 border border-gray-300 rounded-sm focus:outline-none focus:border-[#b33953] transition-colors"></textarea>
             </div>
             <div className="text-center">
-              <button type="submit" className="inline-block bg-[#232024] text-[#f7f7f7] px-12 py-4 hover:bg-[#b33953] transition-colors duration-300 cursor-pointer" style={{ fontFamily: '"Shippori Mincho", serif' }}>
-                送信
+              <button type="submit" className="inline-block bg-[#232024] text-[#f7f7f7] px-12 py-4 hover:bg-[#b33953] transition-colors duration-300 cursor-pointer">
+                Send
               </button>
             </div>
           </form>

--- a/src/components/PhotosClientPage.tsx
+++ b/src/components/PhotosClientPage.tsx
@@ -163,8 +163,8 @@ export default function PhotosClientPage() {
   return (
     <main className="bg-[#ffffff] text-[#232024] py-20 px-4 md:px-8 lg:px-16 min-h-screen">
       <div className="max-w-full mx-auto">
-        <h1 className="text-4xl font-medium mb-16 text-center pt-16" style={{ fontFamily: '"Shippori Mincho", serif' }}>
-          Photos
+        <h1 className="text-5xl font-extrabold mb-12 mt-24 text-center">
+          Gallary
         </h1>
         <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 lg:grid-cols-6 xl:grid-cols-7 2xl:grid-cols-8 gap-px">
           {initialPhotos.map((photo, index) => (


### PR DESCRIPTION
## Summary
- Rename gallery page heading to "Gallary" and style it like the Works page.
- Translate contact page to English and unify its heading and form text with Works styling.

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a957c20c388328918b7efcaab1e469