### PR TITLE
Move work page back button inward

### DIFF
--- a/src/components/BackButton.tsx
+++ b/src/components/BackButton.tsx
@@ -9,7 +9,7 @@ export default function BackButton() {
   return (
     <button
       onClick={() => router.back()}
-      className="absolute bottom-4 left-4 z-10 rounded-full bg-white/70 px-3 py-2 text-sm hover:bg-white"
+      className="absolute bottom-8 left-8 z-10 rounded-full bg-white/70 px-3 py-2 text-sm hover:bg-white"
     >
       ← Back
     </button>


### PR DESCRIPTION
## Summary
- move work page back button further from screen edge for improved spacing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aac9ff20bc8328bb293f9bb32e62b3