### PR TITLE
Change WORKS label to works?

### DIFF
--- a/src/app/works/page.tsx
+++ b/src/app/works/page.tsx
@@ -47,7 +47,7 @@ const WorksPage: React.FC<WorksPageProps> = ({ searchParams }) => {
   return (
     <div className="min-h-screen bg-white text-gray-900 p-8">
       <h1 className="text-5xl font-extrabold mb-12 mt-24 text-center">
-        Works
+        works?
       </h1>
       <div className="flex justify-center flex-wrap gap-2 mb-12 text-sm">
         <Link

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -73,7 +73,7 @@ export default function Header({ textColor }: HeaderProps) {
                   onMouseEnter={textEnter}
                   onMouseLeave={textLeave}
                 >
-                  works
+                  works?
                 </span>
               </Link>
             </li>

--- a/src/components/InterestsSection.tsx
+++ b/src/components/InterestsSection.tsx
@@ -345,7 +345,7 @@ export default function InterestsSection() {
               href={getWorksLink(interest.title)}
               className="inline-block mt-4 text-sm underline"
             >
-              works →
+              works? →
             </Link>
           </div>
         </motion.div>
@@ -678,7 +678,7 @@ return (
                   href={getWorksLink(interest.title)}
                   className="inline-block mt-4 text-sm underline"
                 >
-                  works →
+                  works? →
                 </Link>
               )}
             </div>


### PR DESCRIPTION
## Summary
- rename Works page heading to "works?"
- update navigation and links to display "works?"

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aacae094e08328a35f65a701f52e43