### PR TITLE
Rename site to ぼくは五目飯 and add favicon

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="#f5f5f5"/>
+  <ellipse cx="50" cy="40" rx="30" ry="20" fill="#ffffff" stroke="#333" stroke-width="3"/>
+  <path d="M20 40 L80 40 L70 80 H30 Z" fill="#cccccc" stroke="#333" stroke-width="3"/>
+</svg>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,8 +4,9 @@ import "../globals.css";
 import ClientLayout from "@/components/ClientLayout";
 
 export const metadata: Metadata = {
-  title: "YUDAI | Architectural Designer & Software Engineer",
+  title: "ぼくは五目飯",
   description: "The portfolio of YUDAI, exploring the intersection of architecture and technology.",
+  icons: { icon: "/favicon.svg" },
 };
 
 export const viewport: Viewport = {

--- a/src/app/metadata.ts
+++ b/src/app/metadata.ts
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "YUDAI | Architectural Designer & Software Engineer",
+  title: "ぼくは五目飯",
   description: "The portfolio of YUDAI, exploring the intersection of architecture and technology.",
+  icons: { icon: "/favicon.svg" },
 };

--- a/src/components/__tests__/PhotosClientPage.test.tsx
+++ b/src/components/__tests__/PhotosClientPage.test.tsx
@@ -29,28 +29,28 @@ describe('PhotosClientPage modal behavior', () => {
     render(<PhotosClientPage />);
 
     // Open modal by clicking first photo
-    fireEvent.click(screen.getByAltText('Europe Trip 1'));
+    fireEvent.click(screen.getAllByRole('img')[0]);
 
     // Modal shows first photo and body overflow hidden
-    expect(screen.getByText('Europe Trip 1')).toBeInTheDocument();
+    expect(screen.getByText('ヨーロッパの街並み。')).toBeInTheDocument();
     expect(document.body.style.overflow).toBe('hidden');
 
     // Go to next photo
     fireEvent.keyDown(window, { key: 'ArrowRight' });
-    expect(screen.getByText('Europe Trip 2')).toBeInTheDocument();
+    expect(screen.getByText('アルハンブラ宮殿。')).toBeInTheDocument();
 
     // Go back to previous photo
     fireEvent.keyDown(window, { key: 'ArrowLeft' });
-    expect(screen.getByText('Europe Trip 1')).toBeInTheDocument();
+    expect(screen.getByText('ヨーロッパの街並み。')).toBeInTheDocument();
 
     // Close modal with Escape
     fireEvent.keyDown(window, { key: 'Escape' });
-    expect(screen.queryByText('Europe Trip 1')).not.toBeInTheDocument();
+    expect(screen.queryByText('ヨーロッパの街並み。')).not.toBeInTheDocument();
     expect(document.body.style.overflow).toBe('unset');
     expect(document.body.style.paddingRight).toBe('0px');
 
     // Ensure key listeners removed by pressing ArrowRight again
     fireEvent.keyDown(window, { key: 'ArrowRight' });
-    expect(screen.queryByText('Europe Trip 2')).not.toBeInTheDocument();
+    expect(screen.queryByText('アルハンブラ宮殿。')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- update site metadata title to ぼくは五目飯 and include favicon
- add simple rice bowl favicon
- adjust PhotosClientPage tests to match Japanese image captions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac7b9540cc83289d73d9a882fb1fef