### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/src/app/works/[id]/WorkContent.tsx
+++ b/src/app/works/[id]/WorkContent.tsx
@@ -41,8 +41,8 @@ export default function WorkContent({ work, images }: WorkContentProps) {
           visible ? 'opacity-100' : 'opacity-0'
         }`}
       >
-        <div className="flex-shrink-0 h-full w-[40vw] flex items-center p-8">
-          <div className="max-w-md text-left">
+        <div className="flex-shrink-0 h-full w-full md:w-[40vw] flex items-center p-4 md:p-8">
+          <div className="max-w-md text-left mx-auto md:mx-0">
             <h1
               className="text-4xl font-bold mb-6"
               style={{ fontFamily: '"Shippori Mincho", serif' }}
@@ -84,9 +84,9 @@ function ResponsiveImage({ src, alt }: { src: string; alt: string }) {
 
   if (isGif) {
     return (
-      <div className="flex-shrink-0 h-full flex items-center justify-center px-4">
+      <div className="flex-shrink-0 w-screen md:w-auto h-[80vh] md:h-full flex items-center justify-center px-4">
         <div
-          className="relative h-[80%] p-4 bg-white/20 rounded-lg backdrop-blur-sm shadow-lg"
+          className="relative w-full h-full md:h-[80%] md:w-auto p-4 bg-white/20 rounded-lg backdrop-blur-sm shadow-lg"
           style={{ aspectRatio: ratio }}
         >
           {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -105,9 +105,9 @@ function ResponsiveImage({ src, alt }: { src: string; alt: string }) {
   }
 
   return (
-    <div className="flex-shrink-0 h-full flex items-center justify-center px-4">
+    <div className="flex-shrink-0 w-screen md:w-auto h-[80vh] md:h-full flex items-center justify-center px-4">
       <div
-        className="relative h-[80%] p-4 bg-white/20 rounded-lg backdrop-blur-sm shadow-lg"
+        className="relative w-full h-full md:h-[80%] md:w-auto p-4 bg-white/20 rounded-lg backdrop-blur-sm shadow-lg"
         style={{ aspectRatio: ratio }}
       >
         <FadeInImage

--- a/src/app/works/[id]/WorkContent.tsx
+++ b/src/app/works/[id]/WorkContent.tsx
@@ -86,7 +86,7 @@ function ResponsiveImage({ src, alt }: { src: string; alt: string }) {
     return (
       <div className="flex-shrink-0 h-full flex items-center justify-center px-4">
         <div
-          className="relative h-[80%] p-4 bg-white/20 rounded-lg backdrop-blur-sm shadow-lg overflow-hidden"
+          className="relative h-[80%] p-4 bg-white/20 rounded-lg backdrop-blur-sm shadow-lg"
           style={{ aspectRatio: ratio }}
         >
           {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -107,7 +107,7 @@ function ResponsiveImage({ src, alt }: { src: string; alt: string }) {
   return (
     <div className="flex-shrink-0 h-full flex items-center justify-center px-4">
       <div
-        className="relative h-[80%] p-4 bg-white/20 rounded-lg backdrop-blur-sm shadow-lg overflow-hidden"
+        className="relative h-[80%] p-4 bg-white/20 rounded-lg backdrop-blur-sm shadow-lg"
         style={{ aspectRatio: ratio }}
       >
         <FadeInImage

--- a/src/app/works/[id]/WorkContent.tsx
+++ b/src/app/works/[id]/WorkContent.tsx
@@ -41,7 +41,7 @@ export default function WorkContent({ work, images }: WorkContentProps) {
           visible ? 'opacity-100' : 'opacity-0'
         }`}
       >
-        <div className="flex-shrink-0 h-full w-full md:w-[40vw] flex items-center p-4 md:p-8">
+        <div className="flex-shrink-0 h-full w-full md:w-[40vw] flex items-center p-4 md:p-8 mt-24 md:mt-0">
           <div className="max-w-md text-left mx-auto md:mx-0">
             <h1
               className="text-4xl font-bold mb-6"
@@ -84,9 +84,9 @@ function ResponsiveImage({ src, alt }: { src: string; alt: string }) {
 
   if (isGif) {
     return (
-      <div className="flex-shrink-0 w-screen md:w-auto h-[80vh] md:h-full flex items-center justify-center px-4">
+      <div className="flex-shrink-0 w-screen md:w-auto h-[80vh] md:h-full flex items-end justify-center px-4 mt-24 md:mt-0">
         <div
-          className="relative w-full h-full md:h-[80%] md:w-auto p-4 bg-white/20 rounded-lg backdrop-blur-sm shadow-lg"
+          className="relative w-full h-[70vh] md:h-[80%] md:w-auto"
           style={{ aspectRatio: ratio }}
         >
           {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -105,9 +105,9 @@ function ResponsiveImage({ src, alt }: { src: string; alt: string }) {
   }
 
   return (
-    <div className="flex-shrink-0 w-screen md:w-auto h-[80vh] md:h-full flex items-center justify-center px-4">
+    <div className="flex-shrink-0 w-screen md:w-auto h-[80vh] md:h-full flex items-end justify-center px-4 mt-24 md:mt-0">
       <div
-        className="relative w-full h-full md:h-[80%] md:w-auto p-4 bg-white/20 rounded-lg backdrop-blur-sm shadow-lg"
+        className="relative w-full h-[70vh] md:h-[80%] md:w-auto"
         style={{ aspectRatio: ratio }}
       >
         <FadeInImage

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -5,13 +5,13 @@ import { FaXTwitter } from 'react-icons/fa6';
 
 const Footer = () => {
   return (
-    <footer className="text-[#f7f7f7] py-2 px-8">
+    <footer className="text-[#f7f7f7] py-4 px-6 sm:px-8">
       <div className="max-w-4xl mx-auto">
         <div className="flex flex-col md:flex-row justify-between items-center">
           <div className="mb-4 md:mb-0 text-center md:text-left">
-            <p className="text-sm">&copy; {new Date().getFullYear()} YUDAI. All Rights Reserved.</p>
+            <p className="text-xs sm:text-sm">&copy; {new Date().getFullYear()} YUDAI. All Rights Reserved.</p>
           </div>
-          <div className="flex space-x-4">
+          <div className="flex space-x-6">
             <Link
               href="https://www.instagram.com/babachan_1222/"
               target="_blank"

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -18,7 +18,7 @@ export default function Header({ textColor }: HeaderProps) {
 
   return (
     <header
-      className={`fixed top-0 left-0 z-50 w-full py-6 px-8 md:py-8 md:px-12 transition-colors duration-300 bg-transparent ${textColor}`}
+      className={`fixed top-0 left-0 z-50 w-full py-4 px-6 md:py-8 md:px-12 transition-colors duration-300 bg-transparent ${textColor}`}
     >
       <div className="flex justify-between items-center max-w-7xl mx-auto relative z-50">
         {/* Left side - Logo */}
@@ -39,7 +39,7 @@ export default function Header({ textColor }: HeaderProps) {
         </Link>
 
         {/* Right side - Navigation */}
-        <nav className="pr-8 hidden md:block">
+        <nav className="pr-4 hidden md:block">
           <ul className="flex flex-row items-center space-x-6 md:space-x-8">
             <li>
               <Link href="/about">
@@ -110,7 +110,7 @@ export default function Header({ textColor }: HeaderProps) {
         }`}
       >
         <nav className="flex-1 flex flex-col justify-center items-center px-8">
-          <ul className="flex flex-col items-center space-y-8">
+          <ul className="flex flex-col items-center space-y-6">
             <li>
               <Link href="/about">
                 <span

--- a/src/components/WorkCard.tsx
+++ b/src/components/WorkCard.tsx
@@ -60,7 +60,7 @@ const WorkCard: React.FC<WorkCardProps> = ({
               src={image}
               alt={title}
               fill
-              className="object-cover transition-transform duration-500 ease-in-out group-hover:scale-110"
+              className="object-contain transition-transform duration-500 ease-in-out group-hover:scale-105"
             />
           </div>
         </div>

--- a/src/components/WorkCard.tsx
+++ b/src/components/WorkCard.tsx
@@ -60,7 +60,7 @@ const WorkCard: React.FC<WorkCardProps> = ({
               src={image}
               alt={title}
               fill
-              className="object-contain transition-transform duration-500 ease-in-out group-hover:scale-105"
+              className="object-cover transition-transform duration-500 ease-in-out group-hover:scale-105"
             />
           </div>
         </div>

--- a/src/globals.css
+++ b/src/globals.css
@@ -134,7 +134,8 @@ body {
     linear-gradient(0deg, transparent 24%, rgba(0,0,0,.1) 25%, rgba(0,0,0,.1) 26%, transparent 27%, transparent 74%, rgba(0,0,0,.1) 75%, rgba(0,0,0,.1) 76%, transparent 77%, transparent),
     linear-gradient(90deg, transparent 24%, rgba(0,0,0,.1) 25%, rgba(0,0,0,.1) 26%, transparent 27%, transparent 74%, rgba(0,0,0,.1) 75%, rgba(0,0,0,.1) 76%, transparent 77%, transparent);
   background-size: 50px 50px; /* Adjust grid size as needed */
-  font-size: 0.95rem; /* 基本の文字サイズを少し小さくする */
+  /* Fluid base font size for better responsiveness */
+  font-size: clamp(0.9rem, calc(0.9rem + 0.2vw), 1rem);
   line-height: 1.8; /* 行間を広げる */
 }
 


### PR DESCRIPTION
## Summary
- refine base typography with fluid CSS clamp for better scaling on small screens
- streamline header and mobile menu spacing for handheld devices
- adjust footer padding and text sizing for clearer mobile presentation

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bcd79310188328ba27487bbd3b6a9b