### PR TITLE
feat: enable vertical scrolling on mobile work pages

### DIFF
--- a/src/app/works/[id]/WorkContent.tsx
+++ b/src/app/works/[id]/WorkContent.tsx
@@ -22,7 +22,15 @@ interface WorkContentProps {
 }
 
 export default function WorkContent({ work, images }: WorkContentProps) {
-  const scrollRef = useHorizontalScroll<HTMLDivElement>();
+  const [isMobile, setIsMobile] = useState(false);
+  useEffect(() => {
+    const check = () => setIsMobile(window.innerWidth < 768);
+    check();
+    window.addEventListener('resize', check);
+    return () => window.removeEventListener('resize', check);
+  }, []);
+
+  const scrollRef = useHorizontalScroll<HTMLDivElement>(!isMobile);
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
@@ -33,15 +41,15 @@ export default function WorkContent({ work, images }: WorkContentProps) {
   return (
     <main
       ref={scrollRef}
-      className="relative h-screen w-screen overflow-x-auto overflow-y-hidden text-gray-900"
+      className="relative w-screen min-h-screen overflow-y-auto overflow-x-hidden text-gray-900 md:h-screen md:overflow-x-auto md:overflow-y-hidden"
       style={{ backgroundColor: work.bgColor }}
     >
       <div
-        className={`flex h-full w-full transition-opacity duration-700 ease-out ${
+        className={`flex w-full transition-opacity duration-700 ease-out ${
           visible ? 'opacity-100' : 'opacity-0'
-        }`}
+        } flex-col md:flex-row md:h-full`}
       >
-        <div className="flex-shrink-0 h-full w-[40vw] flex items-center p-8">
+        <div className="flex-shrink-0 w-full md:w-[40vw] md:h-full flex items-center p-8">
           <div className="max-w-md text-left">
             <h1
               className="text-4xl font-bold mb-6"
@@ -84,9 +92,9 @@ function ResponsiveImage({ src, alt }: { src: string; alt: string }) {
 
   if (isGif) {
     return (
-      <div className="flex-shrink-0 h-full flex items-center justify-center px-4">
+      <div className="flex-shrink-0 flex items-center justify-center px-4 w-full md:w-auto md:h-full">
         <div
-          className="relative h-[80%] p-4 bg-white/20 rounded-lg backdrop-blur-sm shadow-lg overflow-hidden"
+          className="relative w-full md:h-[80%] p-4 bg-white/20 rounded-lg backdrop-blur-sm shadow-lg overflow-hidden"
           style={{ aspectRatio: ratio }}
         >
           {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -105,9 +113,9 @@ function ResponsiveImage({ src, alt }: { src: string; alt: string }) {
   }
 
   return (
-    <div className="flex-shrink-0 h-full flex items-center justify-center px-4">
+    <div className="flex-shrink-0 flex items-center justify-center px-4 w-full md:w-auto md:h-full">
       <div
-        className="relative h-[80%] p-4 bg-white/20 rounded-lg backdrop-blur-sm shadow-lg overflow-hidden"
+        className="relative w-full md:h-[80%] p-4 bg-white/20 rounded-lg backdrop-blur-sm shadow-lg overflow-hidden"
         style={{ aspectRatio: ratio }}
       >
         <FadeInImage

--- a/src/hooks/useHorizontalScroll.ts
+++ b/src/hooks/useHorizontalScroll.ts
@@ -3,10 +3,12 @@
 
 import { useRef, useEffect } from 'react';
 
-export default function useHorizontalScroll<T extends HTMLElement>() {
+export default function useHorizontalScroll<T extends HTMLElement>(enabled = true) {
   const containerRef = useRef<T>(null);
 
   useEffect(() => {
+    if (!enabled) return;
+
     const el = containerRef.current;
     if (!el) return;
 
@@ -38,7 +40,7 @@ export default function useHorizontalScroll<T extends HTMLElement>() {
       el.removeEventListener('wheel', onWheel);
       if (rafId !== null) cancelAnimationFrame(rafId);
     };
-  }, []);
+  }, [enabled]);
 
   return containerRef;
 }


### PR DESCRIPTION
## Summary
- switch work pages to vertical layout on small screens
- disable horizontal scroll hook on mobile devices

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bcefb0beac8328b86bdbdf48fde625